### PR TITLE
resume: add `edgar resume <run_dir>` to continue an interrupted run

### DIFF
--- a/edgar/cli.py
+++ b/edgar/cli.py
@@ -30,6 +30,12 @@ run
         edgar run projects/my_task/config.yaml
         edgar run runs/05-01/14-32-10/task_spec.yaml
 
+resume
+    Resume a crashed or interrupted run from its output directory. Picks up at
+    the next unfinished generation and writes back into the same directory:
+
+        edgar resume program_databases/05-26/14-54-15/
+
     Control logging verbosity (default: compact):
 
         edgar run projects/my_task/config.yaml --log-level code
@@ -385,6 +391,44 @@ def _build_and_run(config_path: str, overrides: list[str], log_level: str) -> No
     asyncio.run(run(spec, log_level=log_level))
 
 
+def _build_and_resume(run_dir: str, log_level: str) -> int:
+    """Resume a crashed/interrupted run from its output directory.
+
+    Rebuilds the TaskSpec from the run's frozen task_spec.yaml and continues
+    the evolution loop at the next unfinished generation. Output is written
+    back into the same directory.
+    """
+    import asyncio
+    from .io.config import Config
+    from .io.task_spec import TaskSpec
+    from .io.status import read_status
+    from .run import run
+
+    run_path = Path(run_dir).expanduser().resolve()
+    task_spec_path = run_path / "task_spec.yaml"
+    if not task_spec_path.exists():
+        print(f"error: not a run directory (no task_spec.yaml): {run_path}")
+        return 1
+
+    status = read_status(run_path) or {}
+    state = status.get("state")
+    if state == "complete":
+        print(f"error: run is already complete (status.state={state!r}): {run_path}")
+        return 1
+    if state not in (None, "starting", "running", "failed"):
+        print(f"error: unrecognised status.state={state!r}; refusing to resume.")
+        return 1
+
+    config = Config.from_taskspec(task_spec_path)
+    spec = TaskSpec.from_config(config)
+    print(f"Resuming run at: {run_path}")
+    print(
+        f"  previous status: state={state!r} current_gen={status.get('current_gen')!r}"
+    )
+    asyncio.run(run(spec, log_level=log_level, resume_from=run_path))
+    return 0
+
+
 def _run_test_fake() -> None:
     import sys
 
@@ -495,6 +539,22 @@ def build_parser() -> argparse.ArgumentParser:
     _add_run_args("run", "Run an EDGAR experiment from a config.yaml or task_spec.yaml")
     _add_run_args("test", "Run a small test experiment with reduced evolution settings")
 
+    p_resume = sub.add_parser(
+        "resume",
+        help="Resume a crashed/interrupted run from its output directory",
+    )
+    p_resume.add_argument(
+        "run_dir",
+        type=str,
+        help="Path to a run directory (containing task_spec.yaml + population.jsonl + island_census.jsonl)",
+    )
+    p_resume.add_argument(
+        "--log-level",
+        choices=["compact", "code", "prompts"],
+        default="compact",
+        help="Logging verbosity: compact (default), code, or prompts",
+    )
+
     sub.add_parser(
         "test-fake",
         help="Run a small end-to-end pipeline with fake LLM responses (no real API calls)",
@@ -537,6 +597,9 @@ def run_cli(argv=None) -> int:
         print("Running test run with real LLM calls...")
         _build_and_run(args.config, TEST_OVERRIDES + overrides, args.log_level)
         return 0
+    if args.command == "resume":
+        print("Resuming experiment...")
+        return _build_and_resume(args.run_dir, args.log_level)
 
     if args.command == "test-fake":
         print("Running test run with fake LLM calls...")

--- a/edgar/dashboard/data.py
+++ b/edgar/dashboard/data.py
@@ -26,12 +26,14 @@ import yaml
 from ..evolution.island import load_island_census
 from ..evolution.population import Population
 from ..evolution.program import NotValidated, Program
+from ..io.metrics import METRICS_FILENAME, read_metrics
 from ..io.status import read_status
 
 
 # ── Population cache (path, mtime) → Population ──
 _POP_CACHE: dict[str, tuple[float, Population]] = {}
 _CENSUS_CACHE: dict[str, tuple[float, list[list[set[int]]]]] = {}
+_METRICS_CACHE: dict[str, tuple[float, list[dict]]] = {}
 
 
 def _load_population(run_dir: Path) -> Population | None:
@@ -82,6 +84,72 @@ def _load_census(run_dir: Path) -> list[list[set[int]]]:
     return census
 
 
+def _load_metrics(run_dir: Path) -> list[dict]:
+    """Cached metrics.jsonl loader. [] if not yet written."""
+    path = run_dir / METRICS_FILENAME
+    if not path.exists():
+        return []
+    try:
+        mtime = path.stat().st_mtime
+    except FileNotFoundError:
+        return []
+    key = str(path)
+    cached = _METRICS_CACHE.get(key)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+    rows = read_metrics(run_dir)
+    _METRICS_CACHE[key] = (mtime, rows)
+    return rows
+
+
+def _summarise_metrics(rows: list[dict]) -> dict:
+    """Cumulative totals across all generation rows. Cheap reduction."""
+    totals = {
+        "in_tokens": 0,
+        "out_tokens": 0,
+        "n_llm_calls": 0,
+        "n_llm_retried": 0,
+        "llm_seconds": 0.0,
+        "score_seconds": 0.0,
+        "n_scored": 0,
+        "n_ok": 0,
+        "n_timeout": 0,
+        "n_inf": 0,
+        "by_role": {},
+    }
+    for r in rows:
+        for role, st in (r.get("llm_calls") or {}).items():
+            totals["in_tokens"] += st.get("in_tokens_total", 0) or 0
+            totals["out_tokens"] += st.get("out_tokens_total", 0) or 0
+            totals["n_llm_calls"] += st.get("n", 0) or 0
+            totals["n_llm_retried"] += st.get("retried", 0) or 0
+            mean = (st.get("latency_ms") or {}).get("mean") or 0
+            totals["llm_seconds"] += (mean * (st.get("n", 0) or 0)) / 1000.0
+            by_role = totals["by_role"].setdefault(
+                role,
+                {
+                    "in_tokens": 0,
+                    "out_tokens": 0,
+                    "n": 0,
+                    "retried": 0,
+                    "seconds": 0.0,
+                },
+            )
+            by_role["in_tokens"] += st.get("in_tokens_total", 0) or 0
+            by_role["out_tokens"] += st.get("out_tokens_total", 0) or 0
+            by_role["n"] += st.get("n", 0) or 0
+            by_role["retried"] += st.get("retried", 0) or 0
+            by_role["seconds"] += (mean * (st.get("n", 0) or 0)) / 1000.0
+        sc = r.get("scoring") or {}
+        totals["n_scored"] += sc.get("n", 0) or 0
+        totals["n_ok"] += sc.get("ok", 0) or 0
+        totals["n_timeout"] += sc.get("timeout", 0) or 0
+        totals["n_inf"] += sc.get("inf", 0) or 0
+        mean = (sc.get("latency_ms") or {}).get("mean") or 0
+        totals["score_seconds"] += (mean * (sc.get("n", 0) or 0)) / 1000.0
+    return totals
+
+
 def _load_task_spec(run_dir: Path) -> dict:
     """Load task_spec.yaml. Trust boundary is local-only: this file was written
     by the same machine running the dashboard, so we tolerate Python-object
@@ -102,7 +170,7 @@ def _load_task_spec(run_dir: Path) -> dict:
             return {}
 
 
-def _read_log_tail(run_dir: Path, max_lines: int = 80) -> list[str]:
+def _read_log_tail(run_dir: Path, max_lines: int = 200) -> list[str]:
     path = run_dir / "run.log"
     if not path.exists():
         return []
@@ -315,6 +383,7 @@ def load_run_summary(run_dir: Path) -> dict:
         "n_scored_discover": discover_n,
         "best_discover_loss": best_discover,
         "best_validate_loss": best_validate,
+        "totals": _summarise_metrics(_load_metrics(run_dir)),
     }
 
 
@@ -327,6 +396,8 @@ def load_live_state(run_dir: Path) -> dict:
     derived, is_stale = _derived_state(status_doc)
     pop = _load_population(run_dir)
     census = _load_census(run_dir)
+    metrics_rows = _load_metrics(run_dir)
+    totals = _summarise_metrics(metrics_rows)
 
     evolution = spec.get("evolution") or {}
     n_gens = evolution.get("n_generations") or 0
@@ -348,6 +419,7 @@ def load_live_state(run_dir: Path) -> dict:
         "raw_status": status_doc.get("state", "complete"),
         "is_stale": is_stale,
         "current_gen": current_gen,
+        "current_stage": status_doc.get("current_stage"),
         "n_gens": n_gens,
         "elapsed_s": elapsed_s,
         "eta_s": eta_s,
@@ -359,7 +431,10 @@ def load_live_state(run_dir: Path) -> dict:
         "best_per_gen": best_per_gen,
         "best": best,
         "success_rates": success_rates,
-        "recent_log": _read_log_tail(run_dir, max_lines=14),
+        "metrics": metrics_rows,
+        "totals": totals,
+        "last_metrics": status_doc.get("last_metrics"),
+        "recent_log": _read_log_tail(run_dir, max_lines=60),
         "error": status_doc.get("error")
         or ("run appears stalled (no status update for >60s)" if is_stale else None),
     }

--- a/edgar/dashboard/static/app.js
+++ b/edgar/dashboard/static/app.js
@@ -13,6 +13,7 @@ function dashboard() {
     loading: true,
     autoPoll: true,
     pollIntervalMs: 2500,
+    autoScrollLog: true,
     _pollTimer: null,
 
     // sort
@@ -107,7 +108,7 @@ function dashboard() {
         if (!this.autoPoll || !this.runId) return;
         // Always poll state (cheap) so the live view updates.
         await this.fetchState();
-        // When the run is live and we're in inspect, also refresh the table.
+        // When the run is live, refresh whichever view-specific data we need.
         if (this.state.status === 'running' || this.state.status === 'starting') {
           if (this.view === 'inspect') {
             await this.fetchPrograms();
@@ -147,6 +148,21 @@ function dashboard() {
       if (h) return `${h}h ${m}m`;
       if (m) return `${m}m ${s}s`;
       return `${s}s`;
+    },
+    fmtTokens(n) {
+      if (n === null || n === undefined) return '-';
+      if (n < 1000) return String(n);
+      if (n < 1e6) return `${(n / 1000).toFixed(1)}k`;
+      return `${(n / 1e6).toFixed(2)}M`;
+    },
+    fmtPct(a, b) {
+      if (!a || !b) return '0%';
+      return `${Math.round((a / b) * 100)}%`;
+    },
+    scrollLogTail() {
+      if (!this.autoScrollLog) return;
+      const el = document.getElementById('run-log-tail');
+      if (el) el.scrollTop = el.scrollHeight;
     },
     rateStr(r) {
       if (r === null || r === undefined) return '-';
@@ -220,6 +236,7 @@ function dashboard() {
       requestAnimationFrame(() => {
         this.renderSwimlanes();
         this.renderSpark();
+        this.renderStageChart();
       });
     },
 
@@ -230,12 +247,14 @@ function dashboard() {
       const traces = [];
       const lossOf = p => p.loss_discover ?? p.loss_validate;
       const colors = islands.map((_, i) => islandColor(i));
+      let maxGen = 0;
       islands.forEach((row, ri) => {
         const xs = [], ys = [], texts = [], custom = [], markers = [], sizes = [];
         row.programs.forEach(p => {
           xs.push(p.gen);
           ys.push(ri);
           custom.push(p.idx);
+          maxGen = Math.max(maxGen, p.gen);
           const loss = lossOf(p);
           texts.push(
             `<b>${escapeHtml(p.name)}</b><br>#${p.idx} · gen ${p.gen} · island ${p.island}<br>` +
@@ -260,16 +279,23 @@ function dashboard() {
           name: `island ${row.idx}`,
         });
       });
+      // Give the plot an explicit width that scales with the number of gens so
+      // it can overflow horizontally. The outer wrapper div has overflow-x: auto.
+      const totalGens = Math.max(maxGen + 1, this.state.n_gens || 1, 1);
+      const width = Math.max(800, totalGens * 90);
+      el.style.width = `${width}px`;
       const layout = {
+        width,
         paper_bgcolor: 'rgba(0,0,0,0)',
         plot_bgcolor: 'rgba(0,0,0,0)',
         font: { color: '#d4d4d8', family: 'ui-sans-serif' },
         showlegend: false,
-        margin: { l: 64, r: 16, t: 8, b: 36 },
+        margin: { l: 84, r: 16, t: 8, b: 36 },
         xaxis: {
           title: { text: 'generation', font: { size: 11 } },
           gridcolor: '#27272a', zeroline: false,
           dtick: 1,
+          range: [-0.5, totalGens - 0.5],
         },
         yaxis: {
           tickmode: 'array',
@@ -280,7 +306,7 @@ function dashboard() {
         },
         hoverlabel: { bgcolor: '#0a0a0a', bordercolor: '#3f3f46', font: { color: '#fafafa' } },
       };
-      Plotly.react(el, traces, layout, { displayModeBar: false, responsive: true })
+      Plotly.react(el, traces, layout, { displayModeBar: false, responsive: false })
         .then(() => {
           el.removeAllListeners?.('plotly_click');
           el.on('plotly_click', evt => {
@@ -307,6 +333,54 @@ function dashboard() {
         xaxis: { gridcolor: '#27272a', dtick: 1 },
         yaxis: { gridcolor: '#27272a' },
         showlegend: false,
+      }, { displayModeBar: false, responsive: true });
+    },
+
+    renderStageChart() {
+      const el = document.getElementById('stage-chart');
+      if (!el) return;
+      const rows = this.state.metrics || [];
+      // We collapse seed/validate (gen < 0 / gen >= n_gens) into negative xs
+      // for visibility but drop them if there are no real generations yet.
+      const stagePalette = {
+        spawn: '#a1a1aa',
+        generate_models: '#60a5fa',
+        generate_param_ests: '#a78bfa',
+        translate_programs: '#22d3ee',
+        translate_seeds: '#22d3ee',
+        score: '#34d399',
+        score_seeds: '#34d399',
+        score_validate: '#34d399',
+        deduplicate: '#fbbf24',
+        prune: '#fb7185',
+        migrate: '#facc15',
+      };
+      const stageOrder = [
+        'spawn', 'generate_models', 'generate_param_ests',
+        'translate_programs', 'translate_seeds',
+        'score', 'score_seeds', 'score_validate',
+        'deduplicate', 'prune', 'migrate',
+      ];
+      const xs = rows.map(r => r.gen);
+      const traces = [];
+      for (const stage of stageOrder) {
+        const ys = rows.map(r => (r.stage_times && r.stage_times[stage]) || 0);
+        if (ys.every(v => !v)) continue;
+        traces.push({
+          x: xs, y: ys, type: 'bar', name: stage,
+          marker: { color: stagePalette[stage] || '#71717a' },
+          hovertemplate: `${stage}: %{y:.1f}s<br>gen %{x}<extra></extra>`,
+        });
+      }
+      Plotly.react(el, traces, {
+        paper_bgcolor: 'rgba(0,0,0,0)', plot_bgcolor: 'rgba(0,0,0,0)',
+        font: { color: '#a1a1aa', size: 10 },
+        margin: { l: 40, r: 8, t: 4, b: 20 },
+        barmode: 'stack',
+        xaxis: { gridcolor: '#27272a', dtick: 1, title: { text: '' } },
+        yaxis: { gridcolor: '#27272a', title: { text: '' } },
+        showlegend: true,
+        legend: { font: { size: 9 }, orientation: 'h', y: -0.25 },
       }, { displayModeBar: false, responsive: true });
     },
 

--- a/edgar/dashboard/static/index.html
+++ b/edgar/dashboard/static/index.html
@@ -93,7 +93,7 @@
   <!-- ── LIVE VIEW ── -->
   <main x-show="view === 'live'" class="flex-1 flex">
     <section class="flex-1 p-5 space-y-5 min-w-0">
-      <!-- top tiles -->
+      <!-- top tiles: status, gen + current stage, best loss, elapsed/ETA -->
       <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
         <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
           <div class="text-xs text-zinc-500 uppercase">Status</div>
@@ -101,15 +101,16 @@
             <span :class="statusPillClass(state.status)" class="px-2 py-0.5 rounded text-xs font-medium"
               x-text="state.status || 'unknown'"></span>
           </div>
-          <div class="mt-1 text-xs text-zinc-400" x-text="state.error || ''"></div>
+          <div class="mt-1 text-xs text-zinc-400 truncate" x-text="state.error || ''"></div>
         </div>
         <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
-          <div class="text-xs text-zinc-500 uppercase">Generation</div>
+          <div class="text-xs text-zinc-500 uppercase">Generation · stage</div>
           <div class="mt-1 text-xl font-mono">
-            <span x-text="(state.current_gen ?? '-') + 1"></span>
+            <span x-text="(state.current_gen ?? -1) >= 0 ? (state.current_gen + 1) : 'seed'"></span>
             <span class="text-zinc-500">/</span>
             <span x-text="state.n_gens ?? '-'"></span>
           </div>
+          <div class="text-xs text-emerald-300 font-mono truncate" x-text="state.current_stage || '\u00a0'"></div>
         </div>
         <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
           <div class="text-xs text-zinc-500 uppercase">Best loss</div>
@@ -126,41 +127,108 @@
         </div>
       </div>
 
-      <!-- success rates strip + sparkline -->
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <!-- efficiency tiles -->
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
         <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
-          <div class="text-xs text-zinc-500 uppercase">Per-gen best discover loss</div>
-          <div id="spark-chart" class="h-24 mt-1"></div>
+          <div class="text-xs text-zinc-500 uppercase">Tokens (in / out)</div>
+          <div class="mt-1 text-base font-mono">
+            <span x-text="fmtTokens(state.totals?.in_tokens)"></span>
+            <span class="text-zinc-500"> / </span>
+            <span x-text="fmtTokens(state.totals?.out_tokens)"></span>
+          </div>
+          <div class="text-xs text-zinc-500 mt-0.5">
+            <span x-text="state.totals?.n_llm_calls ?? 0"></span> calls
+            <span x-show="state.totals?.n_llm_retried" class="text-amber-400">
+              · <span x-text="state.totals?.n_llm_retried"></span> retried
+            </span>
+          </div>
         </div>
         <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
-          <div class="text-xs text-zinc-500 uppercase">Stage success rates (gen <span x-text="state.success_rates?.gen ?? '-'"></span>)</div>
-          <div class="grid grid-cols-4 gap-2 mt-2 text-center">
-            <template x-for="k in ['model','param_est','jax','scored']" :key="k">
-              <div>
-                <div class="text-xs text-zinc-500" x-text="k"></div>
-                <div class="text-lg font-mono"
-                  :class="rateClass(state.success_rates?.[k])"
-                  x-text="rateStr(state.success_rates?.[k])"></div>
-              </div>
-            </template>
+          <div class="text-xs text-zinc-500 uppercase">LLM time</div>
+          <div class="mt-1 text-base font-mono">
+            <span x-text="fmtDuration(state.totals?.llm_seconds)"></span>
+            <span class="text-zinc-500 text-xs" x-show="state.elapsed_s">
+              (<span x-text="fmtPct(state.totals?.llm_seconds, state.elapsed_s)"></span>)
+            </span>
+          </div>
+          <div class="text-xs text-zinc-500 mt-0.5">vs scoring
+            <span class="font-mono ml-1" x-text="fmtDuration(state.totals?.score_seconds)"></span>
+          </div>
+        </div>
+        <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
+          <div class="text-xs text-zinc-500 uppercase">Scoring outcomes</div>
+          <div class="mt-1 text-base font-mono flex items-center gap-2">
+            <span class="text-emerald-400" x-text="state.totals?.n_ok ?? 0"></span>
+            <span class="text-zinc-600">·</span>
+            <span class="text-amber-400" x-text="state.totals?.n_timeout ?? 0"></span>
+            <span class="text-zinc-600">·</span>
+            <span class="text-rose-400" x-text="state.totals?.n_inf ?? 0"></span>
+          </div>
+          <div class="text-xs text-zinc-500 mt-0.5">ok · timeout · inf</div>
+        </div>
+        <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
+          <div class="text-xs text-zinc-500 uppercase">Programs</div>
+          <div class="mt-1 text-base font-mono">
+            <span x-text="state.n_programs ?? 0"></span>
+            <span class="text-zinc-500"> · alive </span>
+            <span x-text="state.n_alive ?? 0"></span>
+          </div>
+          <div class="text-xs text-zinc-500 mt-0.5">
+            islands <span class="font-mono" x-text="state.n_islands ?? '-'"></span>
           </div>
         </div>
       </div>
 
-      <!-- swimlanes -->
+      <!-- per-gen best loss + per-gen stage breakdown -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
+          <div class="text-xs text-zinc-500 uppercase">Per-gen best discover loss</div>
+          <div id="spark-chart" class="h-32 mt-1"></div>
+        </div>
+        <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
+          <div class="text-xs text-zinc-500 uppercase">Per-gen stage timing (seconds)</div>
+          <div id="stage-chart" class="h-32 mt-1"></div>
+        </div>
+      </div>
+
+      <!-- success rates -->
+      <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
+        <div class="text-xs text-zinc-500 uppercase">Stage success rates (gen <span x-text="state.success_rates?.gen ?? '-'"></span>)</div>
+        <div class="grid grid-cols-4 gap-2 mt-2 text-center">
+          <template x-for="k in ['model','param_est','jax','scored']" :key="k">
+            <div>
+              <div class="text-xs text-zinc-500" x-text="k"></div>
+              <div class="text-lg font-mono"
+                :class="rateClass(state.success_rates?.[k])"
+                x-text="rateStr(state.success_rates?.[k])"></div>
+            </div>
+          </template>
+        </div>
+      </div>
+
+      <!-- swimlanes (now horizontally scrollable for long runs) -->
       <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
         <div class="flex items-center justify-between">
           <div class="text-xs text-zinc-500 uppercase">Islands · programs over generations</div>
-          <div class="text-xs text-zinc-500">click a node for details · hover for tooltip</div>
+          <div class="text-xs text-zinc-500">click a node for details · hover for tooltip · scroll →</div>
         </div>
-        <div id="swimlanes-chart" class="mt-2" style="min-height: 360px;"></div>
+        <div class="mt-2 overflow-x-auto">
+          <div id="swimlanes-chart" style="min-height: 380px;"></div>
+        </div>
       </div>
 
-      <!-- log tail -->
+      <!-- log tail (taller + auto-scroll) -->
       <div class="border border-zinc-800 rounded-lg p-3 bg-zinc-900/40">
-        <div class="text-xs text-zinc-500 uppercase">run.log (tail)</div>
-        <pre class="mt-2 max-h-56 overflow-auto text-[11px] leading-snug font-mono whitespace-pre text-zinc-300"
-          x-text="(state.recent_log || []).join('\n')"></pre>
+        <div class="flex items-center justify-between">
+          <div class="text-xs text-zinc-500 uppercase">run.log (tail)</div>
+          <label class="text-xs text-zinc-500 select-none">
+            <input type="checkbox" x-model="autoScrollLog" class="align-middle"> auto-scroll
+          </label>
+        </div>
+        <pre id="run-log-tail"
+             class="mt-2 max-h-[420px] overflow-auto text-[11px] leading-snug font-mono whitespace-pre text-zinc-300"
+             x-text="(state.recent_log || []).join('\n')"
+             x-effect="state.recent_log; scrollLogTail()"></pre>
       </div>
     </section>
   </main>

--- a/edgar/evolution/population.py
+++ b/edgar/evolution/population.py
@@ -133,13 +133,20 @@ class Population:
                 raw_params_init = d.get("params_init")
                 raw_sample_losses = d.get("sample_losses")
                 raw_sample_losses_init = d.get("sample_losses_init")
+                # save() serializes the NotValidated sentinel as "NOTVALIDATED";
+                # restore the sentinel so rank() / prepare_validation_scoring
+                # see a real NotValidated() instance, not a bare string (which
+                # would crash sorts and break the validate-eligible filter).
+                validate_raw = d["program_losses"]["validate"]
+                if validate_raw.get("final") == "NOTVALIDATED":
+                    validate_raw = {**validate_raw, "final": NotValidated()}
                 program = Program(
                     birth=BirthCertificate(**d["birth"]),
                     code=Code(**d["code"]),
                     name=d["name"],
                     program_losses=Losses(
                         discover=LossPair(**d["program_losses"]["discover"]),
-                        validate=LossPair(**d["program_losses"]["validate"]),
+                        validate=LossPair(**validate_raw),
                     ),
                     n_params=d["n_params"],
                     eval_fingerprint=fingerprint,

--- a/edgar/io/logging.py
+++ b/edgar/io/logging.py
@@ -97,7 +97,7 @@ class RunLog:
     prev_showwarning: Any = None
 
 
-def open_log(output_dir: str, level: str = "compact") -> RunLog:
+def open_log(output_dir: str, level: str = "compact", append: bool = False) -> RunLog:
     """
     Create run.log in output_dir and return a RunLog handle.
 
@@ -107,12 +107,20 @@ def open_log(output_dir: str, level: str = "compact") -> RunLog:
     Args:
         output_dir: Run output directory (spec.output_dir).
         level: Verbosity — "compact", "code", or "prompts".
+        append: If True, open run.log in append mode and write a "RESUMED"
+            banner instead of the fresh-run header. Used by `edgar resume`.
     """
     if level not in LEVELS:
         raise ValueError(f"level must be one of {LEVELS}, got {level!r}")
     os.makedirs(output_dir, exist_ok=True)
-    f = open(os.path.join(output_dir, "run.log"), "w")
-    f.write(f"EDGAR run log  |  level={level}\n{'=' * 60}\n\n")
+    f = open(os.path.join(output_dir, "run.log"), "a" if append else "w")
+    if append:
+        ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        f.write(
+            f"\n{'=' * 60}\n──── RESUMED at {ts}  |  level={level} ────\n{'=' * 60}\n\n"
+        )
+    else:
+        f.write(f"EDGAR run log  |  level={level}\n{'=' * 60}\n\n")
     f.flush()
     log = RunLog(file=f, level=level, start_time=time.monotonic())
 

--- a/edgar/io/logging.py
+++ b/edgar/io/logging.py
@@ -3,10 +3,13 @@ src/io/logging.py
 
 Human-readable run logging for EDGAR experiments.
 
-Creates a single run.log file and appends one summary block per generation.
+Creates a single run.log file. The runner emits a streaming generation banner
++ per-stage start/end lines (via ``edgar.io.metrics.stage_timer``) and one
+summary block at the END of each generation via ``log_generation``.
+
 Verbosity is controlled by the level argument:
 
-  compact  — one summary block per generation (success rates, island state, global best)
+  compact  — streaming progress + end-of-gen summary
   code     — compact + generated code for each program born this generation
   prompts  — code + reconstructed LLM prompts and image paths
 
@@ -15,16 +18,6 @@ prompt schemas, so no prompt state needs to be threaded through the main loop.
 
 Warnings emitted via warnings.warn() during a generation are buffered and
 appended to the end of that generation's block in the log.
-
-Example usage:
-    log = open_log(spec.output_dir, level="compact")
-
-    for gen in range(spec.evolution["n_generations"]):
-        mode, temperature, llms = spec.schedule(i)
-        # ... run generation ...
-        log_generation(log, gen, population, islands, spec)
-
-    close_log(log)
 """
 
 from __future__ import annotations
@@ -40,16 +33,58 @@ from ..evolution.program import NotValidated
 if TYPE_CHECKING:
     from ..evolution.population import Population
     from ..io.task_spec import TaskSpec
+    from ..io.metrics import RunMetrics
 
 
 LEVELS = ("compact", "code", "prompts")
 
 
 def print_and_log(log: RunLog, message: str) -> None:
-    """Print message to console and appent to log file."""
-    print(message)
+    """Print message to console and append to log file."""
+    print(message, flush=True)
     log.file.write(message + "\n")
     log.file.flush()
+
+
+def _llm_display(v: Any) -> str:
+    """Coerce an LLM field (string name OR a pydantic-ai Model instance) into
+    a short display string. Falls back to the type name for opaque objects."""
+    if isinstance(v, str):
+        return v
+    name = getattr(v, "model_name", None)
+    if name:
+        return str(name)
+    return type(v).__name__
+
+
+def gen_banner(
+    log: RunLog,
+    gen: int,
+    n_gens: int,
+    mode: str,
+    temperature: float,
+    llms: Any,
+    n_spawn: int,
+) -> None:
+    """Banner written at the START of each generation. Includes the schedule
+    so the user can correlate behaviour shifts (explore→exploit, temp decay,
+    LLM rotation) with what they see in the log.
+    """
+    model_llm = (
+        llms.model[gen % len(llms.model)]
+        if isinstance(llms.model, list)
+        else llms.model
+    )
+    print_and_log(log, "")
+    print_and_log(
+        log,
+        f"┌── Generation {gen}/{n_gens - 1}  "
+        f"mode={mode}  temp={temperature:.3f}  "
+        f"spawn={n_spawn}  "
+        f"llms[model={_llm_display(model_llm)} "
+        f"param_est={_llm_display(llms.param_est)} "
+        f"jax={_llm_display(llms.model_jax)}]",
+    )
 
 
 @dataclass
@@ -115,6 +150,7 @@ def log_generation(
     population: Population,
     islands: list[set[int]],
     spec: TaskSpec,
+    metrics: "RunMetrics | None" = None,
 ) -> None:
     """
     Append one generation's summary block to the log.
@@ -124,20 +160,19 @@ def log_generation(
     from spec.schedule(gen). Prompts are reconstructed from each program's
     birth metadata and the spec's prompt schemas.
 
+    If ``metrics`` is provided, also surfaces per-stage timing, per-role LLM
+    token totals + retry counts, and scoring outcome breakdown from the
+    active accumulator's bucket for this generation.
+
     Args:
         log: RunLog handle from open_log().
         gen: Generation index (0-based).
         population: Current Population.
         islands: Current island sets (post-prune and deduplicate).
         spec: TaskSpec.
+        metrics: optional RunMetrics — used to surface live per-gen stats.
     """
     f = log.file
-    mode, temperature, llms = spec.schedule(gen)
-    llm = (
-        llms.model[gen % len(llms.model)]
-        if isinstance(llms.model, list)
-        else llms.model
-    )
     born = [
         population[i]
         for i in range(len(population))
@@ -164,23 +199,51 @@ def log_generation(
     this_gen_time = elapsed - log.previous_gen_time
     log.previous_gen_time = elapsed
 
-    f.write(f"{'=' * 60}\n")
+    f.write(f"└── Gen {gen:3d} summary  ({this_gen_time:.1f}s, total {elapsed:.1f}s)\n")
     f.write(
-        f"Gen {gen:3d}  |  {mode}  |  temp={temperature:.3f}  | gen_time={this_gen_time:.1f}s | total time elapsed={elapsed:.1f}s\n"
+        f"    Spawn   {n}  |  model={pct(n_model)}  param_est={pct(n_param_est)}  jax={pct(n_jax)}  scored={pct(n_scored)}\n"
     )
-    f.write(
-        f"LLMs     model={llm}  param_est={llms.param_est}  model_jax={llms.model_jax}\n"
-    )
-    f.write(
-        f"Spawned  {n}  |  model={pct(n_model)}  param_est={pct(n_param_est)}  jax={pct(n_jax)}  scored={pct(n_scored)}\n"
-    )
-    f.write(f"Global best discover loss: {global_best}\n\n")
-    f.write("Best programs on each island:\n")
+    f.write(f"    Global best discover loss: {global_best}\n")
+
+    if metrics is not None:
+        row = metrics._build_gen_row()
+        stage_times = row.get("stage_times") or {}
+        if stage_times:
+            parts = [f"{name}={t:.1f}s" for name, t in stage_times.items()]
+            f.write(f"    Stages  {'  '.join(parts)}\n")
+        llm_calls = row.get("llm_calls") or {}
+        if llm_calls:
+            for role, st in llm_calls.items():
+                lat = st.get("latency_ms") or {}
+                p50 = lat.get("p50")
+                p90 = lat.get("p90")
+                p50_s = f"{p50 / 1000:.1f}s" if p50 is not None else "-"
+                p90_s = f"{p90 / 1000:.1f}s" if p90 is not None else "-"
+                f.write(
+                    f"    LLM[{role:<9}] n={st['n']} ok={st['ok']} retried={st['retried']}  "
+                    f"tokens in={st['in_tokens_total']} out={st['out_tokens_total']}  "
+                    f"latency p50={p50_s} p90={p90_s}\n"
+                )
+        sc = row.get("scoring") or {}
+        if sc.get("n"):
+            lat = sc.get("latency_ms") or {}
+            p50 = lat.get("p50")
+            p90 = lat.get("p90")
+            mx = lat.get("max")
+            p50_s = f"{p50 / 1000:.1f}s" if p50 is not None else "-"
+            p90_s = f"{p90 / 1000:.1f}s" if p90 is not None else "-"
+            mx_s = f"{mx / 1000:.1f}s" if mx is not None else "-"
+            f.write(
+                f"    Scoring n={sc['n']} ok={sc['ok']} timeout={sc['timeout']} inf={sc['inf']}  "
+                f"latency p50={p50_s} p90={p90_s} max={mx_s}\n"
+            )
+
+    f.write("    Best per island:\n")
     for idx, island in enumerate(islands):
         progs = [population[i] for i in island]
         best = min(progs, key=lambda p: p.program_losses.discover.final or float("inf"))
         f.write(
-            f"  Island {idx}  size={len(island)}  best=#{best.idx} {best.name!r}  loss={best.program_losses.discover.final:.6f}\n"
+            f"      Island {idx}  size={len(island)}  best=#{best.idx} {best.name!r}  loss={best.program_losses.discover.final:.6f}\n"
         )
     f.write("\n")
 

--- a/edgar/io/metrics.py
+++ b/edgar/io/metrics.py
@@ -1,0 +1,394 @@
+"""
+edgar/io/metrics.py
+
+In-process metrics accumulator for an EDGAR run. One ``RunMetrics`` instance
+per run. Three consumers read from it:
+
+- ``run.log`` — streaming start/end lines for each stage, plus tick lines
+  during scoring (the slowest stage, and the only one that's serial).
+- ``status.json`` — ``current_stage`` string + the last completed gen's metrics
+  row, so the dashboard can show "now: score 23/48" without re-reading
+  ``metrics.jsonl``.
+- ``metrics.jsonl`` — one JSON row per generation, with stage timings, per-role
+  LLM call stats (n, tokens, latency percentiles, retry count), and scoring
+  outcome counts (ok/timeout/inf, latency percentiles).
+
+``call_llm`` and ``score`` find the active accumulator via a ``contextvars``
+ContextVar set by the ``RunMetrics`` context manager, so we don't have to
+thread a metrics handle through every call site.
+
+Persistence shape per generation (one line in metrics.jsonl):
+
+    {
+      "gen": 2,
+      "stage_times": {"generate_models": 117.3, "score": 622.7, ...},
+      "llm_calls": {
+        "model":     {"n": 48, "ok": 47, "retried": 5, "in_tokens_total": 142000,
+                      "out_tokens_total": 38500, "models": ["claude-sonnet-4-6"],
+                      "latency_ms": {"p50": 4100, "p90": 9800, "max": 22000, "mean": 5300}},
+        "param_est": {...},
+        "jax":       {...}
+      },
+      "scoring": {"n": 48, "ok": 41, "timeout": 5, "inf": 2,
+                  "latency_ms": {"p50": 8200, "p90": 22000, "max": 60000, "mean": 11000}}
+    }
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import statistics
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator, Literal, TYPE_CHECKING
+
+from .status import atomic_write_text, write_status
+
+if TYPE_CHECKING:
+    from .logging import RunLog
+
+
+# Active metrics handle. call_llm / score read from this to find the current
+# accumulator. None outside a run (e.g. unit tests hitting call_llm directly).
+_active_metrics: contextvars.ContextVar["RunMetrics | None"] = contextvars.ContextVar(
+    "_active_metrics",
+    default=None,
+)
+
+METRICS_FILENAME = "metrics.jsonl"
+
+
+# ── per-event records ──
+
+
+@dataclass
+class _LLMCall:
+    role: str
+    model: str
+    latency_ms: float
+    in_tokens: int
+    out_tokens: int
+    finish_reason: str | None
+    retries: int
+    ok: bool
+
+
+@dataclass
+class _ScoreResult:
+    idx: int
+    ms: float
+    outcome: Literal["ok", "timeout", "inf"]
+
+
+# ── accumulator ──
+
+
+@dataclass
+class RunMetrics:
+    """Accumulates timing + counts for a run. Per-generation buckets are reset
+    every ``start_generation()``; cumulative rows live in ``_gen_rows`` and
+    are persisted to ``metrics.jsonl`` on each ``finish_generation()``.
+
+    Usage:
+
+        with RunMetrics(output_dir, run_log, n_gens, started_at) as metrics:
+            with stage_timer(metrics, "translate_seeds"):
+                await translate_programs(...)
+            for gen in range(n_gens):
+                metrics.start_generation(gen)
+                with stage_timer(metrics, "generate_models", n_items=48):
+                    await generate_models(...)
+                ...
+                metrics.finish_generation()
+    """
+
+    output_dir: Path
+    run_log: "RunLog | None"
+    n_gens: int
+    started_at: float
+
+    current_gen: int = -1  # -1 = seed phase
+    current_stage: str | None = None
+    _stage_times: dict[str, float] = field(default_factory=dict)
+    _llm_calls: list[_LLMCall] = field(default_factory=list)
+    _score_results: list[_ScoreResult] = field(default_factory=list)
+
+    # Live progress counters for stages whose tasks complete asynchronously.
+    # Keyed by stage name, value is (k_completed, n_total). Updated by
+    # record_llm_call / record_score_result.
+    _stage_progress: dict[str, tuple[int, int]] = field(default_factory=dict)
+    _stage_progress_n: dict[str, int] = field(default_factory=dict)
+
+    # Past finished gens.
+    _gen_rows: list[dict] = field(default_factory=list)
+
+    _token: Any = None  # contextvar reset token
+
+    # ── context manager: install as the active metrics ──
+
+    def __enter__(self) -> "RunMetrics":
+        self._token = _active_metrics.set(self)
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        _active_metrics.reset(self._token)
+        return False
+
+    # ── recorders ──
+
+    def record_llm_call(
+        self,
+        role: str,
+        model: str,
+        latency_ms: float,
+        in_tokens: int,
+        out_tokens: int,
+        finish_reason: str | None,
+        retries: int,
+        ok: bool,
+    ) -> None:
+        """Append one LLM-call record and bump the current stage's progress
+        counter if the stage was opened with an n_items hint.
+        """
+        self._llm_calls.append(
+            _LLMCall(
+                role=role,
+                model=model,
+                latency_ms=latency_ms,
+                in_tokens=in_tokens,
+                out_tokens=out_tokens,
+                finish_reason=finish_reason,
+                retries=retries,
+                ok=ok,
+            )
+        )
+        self._tick_stage_progress(self.current_stage_root())
+
+    def record_score_result(self, idx: int, ms: float, outcome: str) -> None:
+        """Append one scoring outcome and bump the score stage progress."""
+        self._score_results.append(_ScoreResult(idx=idx, ms=ms, outcome=outcome))
+        self._tick_stage_progress("score")
+
+    # ── stage progress + status.json ──
+
+    def set_current_stage(self, stage: str | None, n_items: int | None = None) -> None:
+        """Push current_stage into status.json. Best-effort; never raises."""
+        self.current_stage = stage
+        if stage is not None and n_items is not None:
+            self._stage_progress[stage] = (0, n_items)
+            self._stage_progress_n[stage] = n_items
+        self._write_status()
+
+    def current_stage_root(self) -> str | None:
+        """Strip the '(k/n)' suffix to get the bare stage name."""
+        s = self.current_stage
+        if s is None:
+            return None
+        return s.split(" (", 1)[0]
+
+    def _tick_stage_progress(self, stage: str | None) -> None:
+        if stage is None:
+            return
+        if stage not in self._stage_progress_n:
+            return
+        n_total = self._stage_progress_n[stage]
+        k_done = self._stage_progress.get(stage, (0, n_total))[0] + 1
+        self._stage_progress[stage] = (k_done, n_total)
+        # Update the user-visible label and flush to status.json. This is cheap:
+        # atomic file write is ~100 µs, even at 200 calls/gen.
+        self.current_stage = f"{stage} ({k_done}/{n_total})"
+        self._write_status()
+
+    def _write_status(self) -> None:
+        try:
+            write_status(
+                self.output_dir,
+                state="running",
+                n_gens=self.n_gens,
+                current_gen=(self.current_gen if self.current_gen >= 0 else None),
+                started_at=self.started_at,
+                current_stage=self.current_stage,
+                last_metrics=(self._gen_rows[-1] if self._gen_rows else None),
+            )
+        except Exception:
+            # Disk hiccups must never fail the run.
+            pass
+
+    # ── per-gen lifecycle ──
+
+    def start_generation(self, gen: int) -> None:
+        """Reset per-gen buckets and bump the generation label."""
+        self.current_gen = gen
+        self._stage_times = {}
+        self._llm_calls = []
+        self._score_results = []
+        self._stage_progress = {}
+        self._stage_progress_n = {}
+
+    def finish_generation(self) -> dict:
+        """Snapshot the current gen, append a row to ``metrics.jsonl``,
+        and return the row.
+        """
+        row = self._build_gen_row()
+        self._gen_rows.append(row)
+        _write_metrics_jsonl(self.output_dir / METRICS_FILENAME, self._gen_rows)
+        return row
+
+    def _build_gen_row(self) -> dict:
+        by_role: dict[str, list[_LLMCall]] = {}
+        for call in self._llm_calls:
+            by_role.setdefault(call.role, []).append(call)
+
+        llm_summary: dict[str, dict] = {}
+        for role, calls in by_role.items():
+            llm_summary[role] = {
+                "n": len(calls),
+                "ok": sum(1 for c in calls if c.ok),
+                "retried": sum(1 for c in calls if c.retries > 0),
+                "in_tokens_total": sum(c.in_tokens for c in calls),
+                "out_tokens_total": sum(c.out_tokens for c in calls),
+                "models": sorted({c.model for c in calls if c.model}),
+                "latency_ms": _percentiles([c.latency_ms for c in calls]),
+            }
+
+        score_summary = {
+            "n": len(self._score_results),
+            "ok": sum(1 for r in self._score_results if r.outcome == "ok"),
+            "timeout": sum(1 for r in self._score_results if r.outcome == "timeout"),
+            "inf": sum(1 for r in self._score_results if r.outcome == "inf"),
+            "latency_ms": _percentiles([r.ms for r in self._score_results]),
+        }
+
+        return {
+            "gen": self.current_gen,
+            "stage_times": dict(self._stage_times),
+            "llm_calls": llm_summary,
+            "scoring": score_summary,
+        }
+
+
+# ── public API ──
+
+
+def get_active_metrics() -> RunMetrics | None:
+    """Return the currently-active ``RunMetrics``, or None outside a run."""
+    return _active_metrics.get()
+
+
+@contextmanager
+def stage_timer(
+    metrics: RunMetrics | None,
+    name: str,
+    n_items: int | None = None,
+    quiet: bool = False,
+) -> Iterator[None]:
+    """Time one stage of the pipeline.
+
+    Streams start/end lines to ``run.log``, updates ``status.json``
+    ``current_stage`` on entry, and records the duration in the current gen's
+    ``stage_times`` bucket on exit. Safe no-op when ``metrics`` is None (used
+    by tests that drive the runner without setting up an accumulator).
+
+    Args:
+        metrics: the active accumulator, or None.
+        name: stage name, e.g. ``"generate_models"`` or ``"score"``.
+        n_items: optional. If provided, ``set_current_stage`` will track a
+            (k/n) progress counter that's updated by ``record_llm_call`` /
+            ``record_score_result`` as each item completes.
+        quiet: don't write start/end lines (useful for sub-millisecond stages
+            like ``spawn`` that would otherwise spam the log).
+    """
+    if metrics is None:
+        yield
+        return
+
+    t0 = time.monotonic()
+    gen_label = _gen_label(metrics.current_gen)
+    n_part = f" ({n_items} items)" if n_items is not None else ""
+    if not quiet:
+        _write_line(metrics.run_log, f"  [{gen_label}] {name}: starting{n_part}")
+    metrics.set_current_stage(name, n_items=n_items)
+
+    try:
+        yield
+    finally:
+        dt = time.monotonic() - t0
+        metrics._stage_times[name] = round(dt, 3)
+        if not quiet:
+            _write_line(metrics.run_log, f"  [{gen_label}] {name}: done in {dt:.1f}s")
+
+
+def stream_line(metrics: RunMetrics | None, msg: str) -> None:
+    """Print one line to console + the run.log file. Safe no-op without metrics."""
+    if metrics is None:
+        print(msg, flush=True)
+        return
+    _write_line(metrics.run_log, msg)
+
+
+def read_metrics(run_dir: Path) -> list[dict]:
+    """Read metrics.jsonl from disk. Returns [] if file is absent or unreadable."""
+    path = run_dir / METRICS_FILENAME
+    if not path.exists():
+        return []
+    out: list[dict] = []
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    out.append(json.loads(line))
+                except json.JSONDecodeError:
+                    # Partial-write race: return what we have so far.
+                    return out
+    except OSError:
+        return []
+    return out
+
+
+# ── helpers ──
+
+
+def _gen_label(gen: int) -> str:
+    return "seed" if gen < 0 else f"gen {gen}"
+
+
+def _percentiles(xs: list[float]) -> dict:
+    if not xs:
+        return {"p50": None, "p90": None, "max": None, "mean": None}
+    xs_sorted = sorted(xs)
+    p90_idx = max(0, min(len(xs_sorted) - 1, int(round(0.9 * (len(xs_sorted) - 1)))))
+    return {
+        "p50": float(statistics.median(xs_sorted)),
+        "p90": float(xs_sorted[p90_idx]),
+        "max": float(xs_sorted[-1]),
+        "mean": float(sum(xs_sorted) / len(xs_sorted)),
+    }
+
+
+def _write_line(run_log: Any, msg: str) -> None:
+    """Stream one line to console + a RunLog file handle. Avoids importing
+    ``edgar.io.logging`` to keep this module dependency-free."""
+    print(msg, flush=True)
+    if run_log is None:
+        return
+    try:
+        run_log.file.write(msg + "\n")
+        run_log.file.flush()
+    except Exception:
+        pass
+
+
+def _write_metrics_jsonl(path: Path, rows: list[dict]) -> None:
+    """Atomically rewrite the full metrics.jsonl from rows.
+
+    Rewriting is simpler than open-append + truncate-on-failure, and JSONL is
+    small (≤ a few dozen rows per run), so the cost is trivial.
+    """
+    payload = "".join(json.dumps(r) + "\n" for r in rows)
+    atomic_write_text(path, payload)

--- a/edgar/io/status.py
+++ b/edgar/io/status.py
@@ -6,12 +6,14 @@ so a polling reader can never observe a torn file.
 
 Schema (status.json):
     {
-        "state":       "starting" | "running" | "complete" | "failed",
-        "current_gen": int | None,
-        "n_gens":      int,
-        "started_at":  float (unix epoch seconds),
-        "updated_at":  float (unix epoch seconds),
-        "error":       str | None
+        "state":         "starting" | "running" | "complete" | "failed",
+        "current_gen":   int | None,
+        "current_stage": str | None,   # e.g. "generate_models (32/48)" or "score (23/48)"
+        "n_gens":        int,
+        "started_at":    float (unix epoch seconds),
+        "updated_at":    float (unix epoch seconds),
+        "error":         str | None,
+        "last_metrics":  dict | None,  # last completed gen's metrics row (see io/metrics.py)
     }
 """
 
@@ -36,17 +38,26 @@ def write_status(
     current_gen: int | None = None,
     started_at: float | None = None,
     error: str | None = None,
+    current_stage: str | None = None,
+    last_metrics: dict | None = None,
 ) -> None:
-    """Atomically write status.json into out_dir."""
+    """Atomically write status.json into out_dir.
+
+    ``current_stage`` and ``last_metrics`` are optional live-progress fields
+    populated by ``edgar.io.metrics``. Existing callers that pass only the
+    coarser fields remain backward-compatible.
+    """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     payload = {
         "state": state,
         "current_gen": current_gen,
+        "current_stage": current_stage,
         "n_gens": int(n_gens),
         "started_at": float(started_at) if started_at is not None else time.time(),
         "updated_at": time.time(),
         "error": error,
+        "last_metrics": last_metrics,
     }
     _atomic_write_json(out_dir / STATUS_FILENAME, payload)
 

--- a/edgar/llm/generate.py
+++ b/edgar/llm/generate.py
@@ -90,6 +90,7 @@ async def _generate_one_model(
         log_raw_llm_response=cfg.get("log_raw_llm_response", False),
         max_tokens=cfg.get("max_tokens"),
         retry_config=cfg.get("retry_config"),
+        role="model",
     )
     if result is None:
         warnings.warn(
@@ -163,6 +164,7 @@ async def _generate_one_param_est(
         log_raw_llm_response=cfg.get("log_raw_llm_response", False),
         max_tokens=cfg.get("max_tokens"),
         retry_config=cfg.get("retry_config"),
+        role="param_est",
     )
     if result is None:
         warnings.warn(
@@ -211,6 +213,7 @@ async def _translate_one_model(
         temperature=1.0,
         retry_config=retry_config,
         max_tokens=max_tokens,
+        role="jax",
     )
     if (
         model_result is not None

--- a/edgar/llm/llm_calling.py
+++ b/edgar/llm/llm_calling.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import random
+import time
 import warnings
 from typing import Union, TypeAlias
 
@@ -24,6 +25,7 @@ from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import RunContext
 
 from ..io.config import RetryConfig
+from ..io.metrics import get_active_metrics
 from .response_schema import ModelSchema, ParamEstSchema, TranslationSchema
 
 LLMOutputTypes: TypeAlias = Union[str, ModelSchema, ParamEstSchema, TranslationSchema]
@@ -120,6 +122,36 @@ class _WarnOnMaxTokensCapability(AbstractCapability):
         return response
 
 
+class _RecordCallCapability(AbstractCapability):
+    """Stash usage + finish_reason + model name from each HTTP model response.
+
+    Always installed by call_llm so we can hand the numbers to ``RunMetrics``
+    after the agent run completes (success or failure). Updates per-response —
+    on retry, the values reflect the most recent HTTP exchange.
+    """
+
+    def __init__(self) -> None:
+        self.input_tokens: int = 0
+        self.output_tokens: int = 0
+        self.finish_reason: str | None = None
+        self.model_name: str | None = None
+
+    async def after_model_request(
+        self,
+        ctx: RunContext,
+        *,
+        request_context: ModelRequestContext,
+        response: ModelResponse,
+    ) -> ModelResponse:
+        usage = response.usage
+        if usage is not None:
+            self.input_tokens = int(usage.input_tokens or 0)
+            self.output_tokens = int(usage.output_tokens or 0)
+        self.finish_reason = (response.provider_details or {}).get("finish_reason")
+        self.model_name = response.model_name
+        return response
+
+
 async def call_llm(
     prompt: str,
     llm_model: str | Model,
@@ -130,6 +162,7 @@ async def call_llm(
     max_tokens: int | None = 10_000,
     log_raw_llm_response: bool = False,
     retry_config: RetryConfig | None = None,
+    role: str | None = None,
 ):
     """
     Call an LLM through PydanticAI and return the parsed output.
@@ -184,7 +217,8 @@ async def call_llm(
         )
 
     rc = retry_config or RetryConfig()
-    capabilities = [_WarnOnMaxTokensCapability()]
+    recorder = _RecordCallCapability()
+    capabilities = [_WarnOnMaxTokensCapability(), recorder]
     if log_raw_llm_response:
         capabilities.append(_LogRawResponseCapability())
     agent = Agent(
@@ -206,41 +240,72 @@ async def call_llm(
         max_tokens=max_tokens,
     )
 
-    delay = rc.initial_delay
-    for attempt in range(rc.max_retries):
-        try:
-            result = await agent.run(user_input, model_settings=model_settings)
-            return result.output
+    # Track per-call_llm wall clock + attempt count for the metrics recorder.
+    # Wall clock includes sleep-between-retries on purpose: that time is what
+    # the run loop actually waits for.
+    t_call_start = time.monotonic()
+    attempt_count = 0
+    ok = False
+    try:
+        delay = rc.initial_delay
+        for attempt in range(rc.max_retries):
+            attempt_count = attempt + 1
+            try:
+                result = await agent.run(user_input, model_settings=model_settings)
+                ok = True
+                return result.output
 
-        except UnexpectedModelBehavior as e:
-            type_name = getattr(output_type, "__name__", repr(output_type))
-            warnings.warn(
-                f"[call_llm] LLM output could not be parsed as {type_name!r} after exhausting retries — skipping. "
-                f"{e.message}"
-            )
-            return None
-
-        except ModelHTTPError as e:
-            if e.status_code not in rc.retryable_status_codes:
+            except UnexpectedModelBehavior as e:
+                type_name = getattr(output_type, "__name__", repr(output_type))
                 warnings.warn(
-                    f"[call_llm] Non-retryable HTTP {e.status_code} error: {e}"
-                )
-                raise
-            if attempt == rc.max_retries - 1:
-                warnings.warn(
-                    f"[call_llm] HTTP {e.status_code} on final attempt {attempt + 1}/{rc.max_retries}. No more retries left. Returning None."
+                    f"[call_llm] LLM output could not be parsed as {type_name!r} after exhausting retries — skipping. "
+                    f"{e.message}"
                 )
                 return None
-            jitter = random.uniform(0, 1)
-            wait = min(delay + jitter, rc.max_delay)
-            warnings.warn(
-                f"[call_llm] HTTP {e.status_code} on attempt {attempt + 1}/{rc.max_retries}, "
-                f"retrying in {wait:.1f}s."
-            )
-            await asyncio.sleep(wait)
-            delay = min(delay * rc.backoff_multiplier, rc.max_delay)
 
-        # ModelAPIError (non-HTTP network failure), UsageLimitExceeded, UserError → propagate immediately
-        except (ModelAPIError, UsageLimitExceeded, UserError) as e:
-            warnings.warn(f"[call_llm] {type(e).__name__} encountered: {e}")
-            raise
+            except ModelHTTPError as e:
+                if e.status_code not in rc.retryable_status_codes:
+                    warnings.warn(
+                        f"[call_llm] Non-retryable HTTP {e.status_code} error: {e}"
+                    )
+                    raise
+                if attempt == rc.max_retries - 1:
+                    warnings.warn(
+                        f"[call_llm] HTTP {e.status_code} on final attempt {attempt + 1}/{rc.max_retries}. No more retries left. Returning None."
+                    )
+                    return None
+                jitter = random.uniform(0, 1)
+                wait = min(delay + jitter, rc.max_delay)
+                warnings.warn(
+                    f"[call_llm] HTTP {e.status_code} on attempt {attempt + 1}/{rc.max_retries}, "
+                    f"retrying in {wait:.1f}s."
+                )
+                await asyncio.sleep(wait)
+                delay = min(delay * rc.backoff_multiplier, rc.max_delay)
+
+            # ModelAPIError (non-HTTP network failure), UsageLimitExceeded, UserError → propagate immediately
+            except (ModelAPIError, UsageLimitExceeded, UserError) as e:
+                warnings.warn(f"[call_llm] {type(e).__name__} encountered: {e}")
+                raise
+    finally:
+        # Record once per call_llm invocation, success or failure. If the run
+        # has no active RunMetrics (tests calling call_llm directly), this is a
+        # no-op.
+        metrics = get_active_metrics()
+        if metrics is not None:
+            latency_ms = (time.monotonic() - t_call_start) * 1000.0
+            resolved_model = recorder.model_name or (
+                llm_model
+                if isinstance(llm_model, str)
+                else getattr(llm_model, "model_name", "unknown")
+            )
+            metrics.record_llm_call(
+                role=role or "unknown",
+                model=str(resolved_model),
+                latency_ms=latency_ms,
+                in_tokens=recorder.input_tokens,
+                out_tokens=recorder.output_tokens,
+                finish_reason=recorder.finish_reason,
+                retries=max(0, attempt_count - 1),
+                ok=ok,
+            )

--- a/edgar/run.py
+++ b/edgar/run.py
@@ -24,8 +24,8 @@ from pathlib import Path
 
 from .io.task_spec import TaskSpec
 from .io.logging import open_log, log_generation, close_log, print_and_log, gen_banner
-from .io.status import write_status
-from .io.metrics import RunMetrics, stage_timer
+from .io.status import write_status, read_status
+from .io.metrics import RunMetrics, stage_timer, read_metrics
 from .evolution.population import Population
 from .evolution.island import (
     seed,
@@ -34,6 +34,7 @@ from .evolution.island import (
     prune,
     migrate,
     save_island_census,
+    load_island_census,
 )
 from .llm.generate import (
     generate_models,
@@ -45,18 +46,53 @@ from .scoring.scoring import rank, score
 from .io.plotting import generate_program_fits
 
 
-async def run(spec: TaskSpec, log_level: str = "compact") -> str:
+async def run(
+    spec: TaskSpec,
+    log_level: str = "compact",
+    resume_from: str | Path | None = None,
+) -> str:
+    """Run an EDGAR experiment, optionally resuming a crashed run.
+
+    Args:
+        spec: TaskSpec built from a config or task_spec.yaml.
+        log_level: Logging verbosity (compact/code/prompts).
+        resume_from: Path to a run directory (containing population.jsonl +
+            island_census.jsonl + task_spec.yaml). When set:
+              - The seed phase is skipped; state is loaded from disk.
+              - Output is written back into ``resume_from`` (spec is restamped).
+              - The loop continues at ``len(census)``.
+              - run.log is opened in append mode with a RESUMED banner.
+              - started_at is preserved from the original status.json so total
+                wall time across resumes is recoverable from gen timings.
+
+            Caveats:
+              - ``spec.rng`` state is lost. With a fixed run.random_seed the
+                resumed spawning/migration draws differ from a continuous run.
+                LLM responses are non-deterministic anyway.
+              - The original task_spec.yaml is reused as-is (chmod read-only).
+    """
+    resume = resume_from is not None
+    if resume:
+        resume_from = Path(resume_from).resolve()
+        _prepare_resume(spec, resume_from)
+
     os.makedirs(spec.output_dir, exist_ok=True)
-    spec.save(spec.output_dir)
-    log = open_log(spec.output_dir, log_level)
+    if not resume:
+        spec.save(spec.output_dir)
+    log = open_log(spec.output_dir, log_level, append=resume)
 
     n_gens = spec.evolution["n_generations"]
-    started_at = time.time()
-    write_status(
-        spec.output_dir, state="starting", n_gens=n_gens, started_at=started_at
-    )
     pop_path = os.path.join(spec.output_dir, "population.jsonl")
     census_path = os.path.join(spec.output_dir, "island_census.jsonl")
+
+    if resume:
+        prior_status = read_status(spec.output_dir) or {}
+        started_at = float(prior_status.get("started_at", time.time()))
+    else:
+        started_at = time.time()
+        write_status(
+            spec.output_dir, state="starting", n_gens=n_gens, started_at=started_at
+        )
 
     X_discover, X_validate, X_eval = spec.load_data_fn(
         data_path=spec.io["data_path"], **spec.project_params
@@ -67,8 +103,19 @@ async def run(spec: TaskSpec, log_level: str = "compact") -> str:
     n_islands = spec.evolution["n_islands"]
     batch_size = spec.evolution["batch_size"]
 
-    population = Population()
-    census = []
+    if resume:
+        population = Population.load(pop_path)
+        census = load_island_census(census_path)
+        _validate_resume_state(population, census, n_gens)
+        n_dropped = _drop_trailing_unscored(population)
+        islands = [set(s) for s in census[-1]]
+        start_gen = len(census)
+    else:
+        population = Population()
+        census = []
+        islands = None  # populated in seed phase below
+        start_gen = 0
+        n_dropped = 0
 
     with RunMetrics(
         output_dir=Path(spec.output_dir),
@@ -77,7 +124,24 @@ async def run(spec: TaskSpec, log_level: str = "compact") -> str:
         started_at=started_at,
     ) as metrics:
         try:
-            print_and_log(log, f"Run started. Output: {spec.output_dir}")
+            if resume:
+                # Restore historical per-gen metrics so the dashboard's
+                # last_metrics reflects the full timeline, not just the resume.
+                metrics._gen_rows.extend(read_metrics(Path(spec.output_dir)))
+                print_and_log(log, f"Run RESUMED from {spec.output_dir}")
+                if n_dropped:
+                    print_and_log(
+                        log,
+                        f"Resume: dropped {n_dropped} trailing unscored programs "
+                        f"(stale spawn shells from the crashed generation).",
+                    )
+                print_and_log(
+                    log,
+                    f"Loaded population={len(population)} programs, "
+                    f"census={len(census)} completed gens. Resuming at gen={start_gen}.",
+                )
+            else:
+                print_and_log(log, f"Run started. Output: {spec.output_dir}")
             print_and_log(
                 log,
                 f"Config: n_gens={n_gens} n_islands={n_islands} "
@@ -86,46 +150,49 @@ async def run(spec: TaskSpec, log_level: str = "compact") -> str:
                 f"critical_pop={spec.evolution['critical_population_size']}",
             )
 
-            # ── Seed phase ──
-            metrics.start_generation(-1)
-            with stage_timer(metrics, "seed", quiet=True):
-                islands = seed(population, spec.seed_programs, n_islands)
-            with stage_timer(
-                metrics, "translate_seeds", n_items=len(spec.seed_programs)
-            ):
-                await translate_programs(
-                    population,
-                    spec.prompt_schemas.jax_model,
-                    spec.llms["jax_model_translator_llm"],
-                    retry_config=retry_config,
-                    max_tokens=config.get("max_tokens"),
+            if not resume:
+                # ── Seed phase ──
+                metrics.start_generation(-1)
+                with stage_timer(metrics, "seed", quiet=True):
+                    islands = seed(population, spec.seed_programs, n_islands)
+                with stage_timer(
+                    metrics, "translate_seeds", n_items=len(spec.seed_programs)
+                ):
+                    await translate_programs(
+                        population,
+                        spec.prompt_schemas.jax_model,
+                        spec.llms["jax_model_translator_llm"],
+                        retry_config=retry_config,
+                        max_tokens=config.get("max_tokens"),
+                    )
+                with stage_timer(
+                    metrics, "score_seeds", n_items=len(spec.seed_programs)
+                ):
+                    score(
+                        population,
+                        X_discover,
+                        X_eval,
+                        spec.scoring,
+                        spec.loss_fn,
+                        split="discover",
+                    )
+                with stage_timer(metrics, "generate_program_fits_seeds", quiet=True):
+                    generate_program_fits(spec, X_discover[1], population)
+                population.save(pop_path)
+                save_island_census(census, census_path)
+                metrics.finish_generation()
+                write_status(
+                    spec.output_dir,
+                    state="running",
+                    n_gens=n_gens,
+                    current_gen=-1,
+                    started_at=started_at,
+                    current_stage=None,
+                    last_metrics=metrics._gen_rows[-1] if metrics._gen_rows else None,
                 )
-            with stage_timer(metrics, "score_seeds", n_items=len(spec.seed_programs)):
-                score(
-                    population,
-                    X_discover,
-                    X_eval,
-                    spec.scoring,
-                    spec.loss_fn,
-                    split="discover",
-                )
-            with stage_timer(metrics, "generate_program_fits_seeds", quiet=True):
-                generate_program_fits(spec, X_discover[1], population)
-            population.save(pop_path)
-            save_island_census(census, census_path)
-            metrics.finish_generation()
-            write_status(
-                spec.output_dir,
-                state="running",
-                n_gens=n_gens,
-                current_gen=-1,
-                started_at=started_at,
-                current_stage=None,
-                last_metrics=metrics._gen_rows[-1] if metrics._gen_rows else None,
-            )
 
             # ── Evolution loop ──
-            for gen in range(n_gens):
+            for gen in range(start_gen, n_gens):
                 metrics.start_generation(gen)
                 mode, temperature, llms = spec.schedule(gen)
                 n_spawn = n_islands * batch_size
@@ -258,6 +325,69 @@ async def run(spec: TaskSpec, log_level: str = "compact") -> str:
             close_log(log)
 
     return
+
+
+def _prepare_resume(spec: TaskSpec, run_dir: Path) -> None:
+    """Restamp ``spec`` so its output_dir resolves to ``run_dir``.
+
+    ``spec.output_dir`` is computed as ``os.path.join(io["save_path"],
+    creation_timestamp)``. Setting save_path to "" and creation_timestamp to
+    the absolute run_dir produces output_dir == str(run_dir).
+    """
+    if not run_dir.exists():
+        raise FileNotFoundError(f"resume_from directory does not exist: {run_dir}")
+    if not (run_dir / "task_spec.yaml").exists():
+        raise FileNotFoundError(
+            f"resume_from is missing task_spec.yaml: {run_dir}. "
+            "This doesn't look like an EDGAR run directory."
+        )
+    spec.io["save_path"] = ""
+    spec.creation_timestamp = str(run_dir)
+
+
+def _drop_trailing_unscored(population: Population) -> int:
+    """Drop programs from the end of population whose discover.final loss is None.
+
+    These are stale spawn shells from a crashed generation: spawn() added them
+    but score() never got the chance to set their loss. Dropping them keeps
+    population.jsonl free of ghost entries after resume. Pruned-but-completed
+    programs from earlier gens are preserved because they have a non-None
+    final loss (or inf if scoring failed cleanly).
+
+    Returns the number of programs dropped.
+    """
+    progs = population._programs
+    n_before = len(progs)
+    while progs and progs[-1].program_losses.discover.final is None:
+        progs.pop()
+    return n_before - len(progs)
+
+
+def _validate_resume_state(population: Population, census: list, n_gens: int) -> None:
+    """Refuse to resume if on-disk state is incomplete, inconsistent, or done."""
+    if len(population) == 0:
+        raise ValueError(
+            "Cannot resume: population.jsonl is empty. The original run did "
+            "not complete its seed phase. Re-run from scratch instead."
+        )
+    if len(census) == 0:
+        raise ValueError(
+            "Cannot resume: island_census.jsonl has no completed generations "
+            "(seed phase saves an empty census). The original run crashed "
+            "before gen 0 finished. Re-run from scratch instead."
+        )
+    if len(census) >= n_gens:
+        raise ValueError(
+            f"Cannot resume: census already has {len(census)} completed gens "
+            f"(target n_generations={n_gens}). The original run reached the "
+            "validation phase; nothing to resume."
+        )
+    max_idx = max((idx for island in census[-1] for idx in island), default=-1)
+    if max_idx >= len(population):
+        raise ValueError(
+            f"Corrupt run dir: census references program idx {max_idx} but "
+            f"population only has {len(population)} programs."
+        )
 
 
 if __name__ == "__main__":

--- a/edgar/run.py
+++ b/edgar/run.py
@@ -23,8 +23,9 @@ import sys
 from pathlib import Path
 
 from .io.task_spec import TaskSpec
-from .io.logging import open_log, log_generation, close_log, print_and_log
+from .io.logging import open_log, log_generation, close_log, print_and_log, gen_banner
 from .io.status import write_status
+from .io.metrics import RunMetrics, stage_timer
 from .evolution.population import Population
 from .evolution.island import (
     seed,
@@ -63,130 +64,198 @@ async def run(spec: TaskSpec, log_level: str = "compact") -> str:
     retry_config = RetryConfig(**spec.llms.get("retry", {}))
     config = {**spec.flat_config, "retry_config": retry_config}
 
+    n_islands = spec.evolution["n_islands"]
+    batch_size = spec.evolution["batch_size"]
+
     population = Population()
     census = []
 
-    try:
-        islands = seed(population, spec.seed_programs, spec.evolution["n_islands"])
-        await translate_programs(
-            population,
-            spec.prompt_schemas.jax_model,
-            spec.llms["jax_model_translator_llm"],
-            retry_config=retry_config,
-            max_tokens=config.get("max_tokens"),
-        )
-        score(
-            population, X_discover, X_eval, spec.scoring, spec.loss_fn, split="discover"
-        )
-        generate_program_fits(spec, X_discover[1], population)
-        population.save(
-            pop_path
-        )  # snapshot of seed phase so the dashboard has data before gen 0 finishes
-        save_island_census(census, census_path)
-        write_status(
-            spec.output_dir,
-            state="running",
-            n_gens=n_gens,
-            current_gen=-1,
-            started_at=started_at,
-        )
-
-        for gen in range(spec.evolution["n_generations"]):
-            print_and_log(log, f"Generation {gen} / {spec.evolution['n_generations']}")
-            mode, temperature, llms = spec.schedule(gen)
-            spawn(
-                population,
-                islands,
-                gen,
-                mode,
-                temperature,
-                batch_size=spec.evolution["batch_size"],
-                num_parents=spec.llms["num_parents"],
-                rng=spec.rng,
+    with RunMetrics(
+        output_dir=Path(spec.output_dir),
+        run_log=log,
+        n_gens=n_gens,
+        started_at=started_at,
+    ) as metrics:
+        try:
+            print_and_log(log, f"Run started. Output: {spec.output_dir}")
+            print_and_log(
+                log,
+                f"Config: n_gens={n_gens} n_islands={n_islands} "
+                f"batch_size={batch_size} "
+                f"num_parents={spec.llms['num_parents']} "
+                f"critical_pop={spec.evolution['critical_population_size']}",
             )
 
-            await generate_models(
-                population,
-                spec.prompt_schemas.model,
-                llms.model[gen % len(llms.model)]
-                if isinstance(llms.model, list)
-                else llms.model,
-                mode,
-                temperature,
-                config=config,
-                spec=spec,
-                data=X_discover[1],
-            )  # use test data of X_discover for plotting
-            await generate_param_ests(
-                population,
-                spec.prompt_schemas.param_est,
-                llms.param_est,
-                config,
-            )
-            await translate_programs(
-                population,
-                spec.prompt_schemas.jax_model,
-                llms.model_jax,
-                retry_config=retry_config,
-            )
-
-            score(
-                population,
-                X_discover,
-                X_eval,
-                spec.scoring,
-                spec.loss_fn,
-                split="discover",
-            )
-            generate_program_fits(spec, X_discover[1], population)
-
-            deduplicate(islands, population, spec.evolution)
-            prune(islands, population, spec.evolution)
-            migrate(islands, population, spec.evolution, temperature, rng=spec.rng)
-            census.append([set(island) for island in islands])
-            log_generation(log, gen, population, islands, spec)
-
-            # Per-generation persistence for the live dashboard. Atomic writes
-            # protect a polling reader from observing torn files.
+            # ── Seed phase ──
+            metrics.start_generation(-1)
+            with stage_timer(metrics, "seed", quiet=True):
+                islands = seed(population, spec.seed_programs, n_islands)
+            with stage_timer(
+                metrics, "translate_seeds", n_items=len(spec.seed_programs)
+            ):
+                await translate_programs(
+                    population,
+                    spec.prompt_schemas.jax_model,
+                    spec.llms["jax_model_translator_llm"],
+                    retry_config=retry_config,
+                    max_tokens=config.get("max_tokens"),
+                )
+            with stage_timer(metrics, "score_seeds", n_items=len(spec.seed_programs)):
+                score(
+                    population,
+                    X_discover,
+                    X_eval,
+                    spec.scoring,
+                    spec.loss_fn,
+                    split="discover",
+                )
+            with stage_timer(metrics, "generate_program_fits_seeds", quiet=True):
+                generate_program_fits(spec, X_discover[1], population)
             population.save(pop_path)
             save_island_census(census, census_path)
+            metrics.finish_generation()
             write_status(
                 spec.output_dir,
                 state="running",
                 n_gens=n_gens,
-                current_gen=gen,
+                current_gen=-1,
                 started_at=started_at,
+                current_stage=None,
+                last_metrics=metrics._gen_rows[-1] if metrics._gen_rows else None,
             )
 
-        population.prepare_validation_scoring(islands)
-        score(
-            population, X_validate, None, spec.scoring, spec.loss_fn, split="validate"
-        )
-        rank(population)
+            # ── Evolution loop ──
+            for gen in range(n_gens):
+                metrics.start_generation(gen)
+                mode, temperature, llms = spec.schedule(gen)
+                n_spawn = n_islands * batch_size
+                gen_banner(log, gen, n_gens, mode, temperature, llms, n_spawn=n_spawn)
 
-        print_and_log(
-            log, f"***** Run complete. Output directory: {spec.output_dir} *****"
-        )
+                with stage_timer(metrics, "spawn", quiet=True):
+                    spawn(
+                        population,
+                        islands,
+                        gen,
+                        mode,
+                        temperature,
+                        batch_size=batch_size,
+                        num_parents=spec.llms["num_parents"],
+                        rng=spec.rng,
+                    )
 
-    finally:  # runs whether or not an exception is raised, ensuring that results are saved
-        exc_info = sys.exc_info()
-        failed = exc_info[0] is not None
-        if failed:
+                with stage_timer(metrics, "generate_models", n_items=n_spawn):
+                    await generate_models(
+                        population,
+                        spec.prompt_schemas.model,
+                        llms.model[gen % len(llms.model)]
+                        if isinstance(llms.model, list)
+                        else llms.model,
+                        mode,
+                        temperature,
+                        config=config,
+                        spec=spec,
+                        data=X_discover[1],
+                    )
+                with stage_timer(metrics, "generate_param_ests", n_items=n_spawn):
+                    await generate_param_ests(
+                        population,
+                        spec.prompt_schemas.param_est,
+                        llms.param_est,
+                        config,
+                    )
+                with stage_timer(metrics, "translate_programs", n_items=n_spawn):
+                    await translate_programs(
+                        population,
+                        spec.prompt_schemas.jax_model,
+                        llms.model_jax,
+                        retry_config=retry_config,
+                        max_tokens=config.get("max_tokens"),
+                    )
+                with stage_timer(metrics, "score", n_items=n_spawn):
+                    score(
+                        population,
+                        X_discover,
+                        X_eval,
+                        spec.scoring,
+                        spec.loss_fn,
+                        split="discover",
+                    )
+                with stage_timer(metrics, "generate_program_fits", quiet=True):
+                    generate_program_fits(spec, X_discover[1], population)
+
+                with stage_timer(metrics, "deduplicate", quiet=True):
+                    deduplicate(islands, population, spec.evolution)
+                with stage_timer(metrics, "prune", quiet=True):
+                    prune(islands, population, spec.evolution)
+                with stage_timer(metrics, "migrate", quiet=True):
+                    migrate(
+                        islands,
+                        population,
+                        spec.evolution,
+                        temperature,
+                        rng=spec.rng,
+                    )
+                census.append([set(island) for island in islands])
+
+                log_generation(log, gen, population, islands, spec, metrics=metrics)
+
+                # Per-generation persistence for the live dashboard. Atomic writes
+                # protect a polling reader from observing torn files.
+                population.save(pop_path)
+                save_island_census(census, census_path)
+                metrics.finish_generation()
+                write_status(
+                    spec.output_dir,
+                    state="running",
+                    n_gens=n_gens,
+                    current_gen=gen,
+                    started_at=started_at,
+                    current_stage=None,
+                    last_metrics=metrics._gen_rows[-1] if metrics._gen_rows else None,
+                )
+
+            # ── Validation ──
+            metrics.start_generation(n_gens)
+            population.prepare_validation_scoring(islands)
+            with stage_timer(metrics, "score_validate"):
+                score(
+                    population,
+                    X_validate,
+                    None,
+                    spec.scoring,
+                    spec.loss_fn,
+                    split="validate",
+                )
+            rank(population)
+            metrics.finish_generation()
+
             print_and_log(
-                log,
-                f"***** Run failed with exception:\n{''.join(traceback.format_exception(*exc_info))}***** Output directory: {spec.output_dir} *****",
+                log, f"***** Run complete. Output directory: {spec.output_dir} *****"
             )
-        population.save(pop_path)
-        save_island_census(census, census_path)
-        write_status(
-            spec.output_dir,
-            state="failed" if failed else "complete",
-            n_gens=n_gens,
-            current_gen=(len(census) - 1) if census else None,
-            started_at=started_at,
-            error=(f"{exc_info[0].__name__}: {exc_info[1]}" if failed else None),
-        )
-        close_log(log)
+
+        finally:  # runs whether or not an exception is raised
+            exc_info = sys.exc_info()
+            failed = exc_info[0] is not None
+            if failed:
+                print_and_log(
+                    log,
+                    f"***** Run failed with exception:\n"
+                    f"{''.join(traceback.format_exception(*exc_info))}"
+                    f"***** Output directory: {spec.output_dir} *****",
+                )
+            population.save(pop_path)
+            save_island_census(census, census_path)
+            write_status(
+                spec.output_dir,
+                state="failed" if failed else "complete",
+                n_gens=n_gens,
+                current_gen=(len(census) - 1) if census else None,
+                started_at=started_at,
+                error=(f"{exc_info[0].__name__}: {exc_info[1]}" if failed else None),
+                current_stage=None,
+                last_metrics=metrics._gen_rows[-1] if metrics._gen_rows else None,
+            )
+            close_log(log)
 
     return
 

--- a/edgar/scoring/scoring.py
+++ b/edgar/scoring/scoring.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import multiprocessing as mp
 import os
+import time
 
 import traceback
 import cloudpickle
@@ -34,6 +35,7 @@ from ..evolution.program import (
     Program,
 )
 from ..evolution.population import Population
+from ..io.metrics import get_active_metrics, stream_line
 
 
 # ── helpers ──
@@ -204,13 +206,42 @@ def _score_one_model(
 ]:
     """Score one program in a spawn subprocess; kill on timeout.
 
-    Returns (final_loss, initial_loss, eval_fingerprint, params, sample_losses, params_init, sample_losses_init).
+    Returns ``(final_loss, initial_loss, eval_fingerprint, params, sample_losses,
+    params_init, sample_losses_init)``. On timeout or worker exception, returns
+    the all-inf 7-tuple. ``score()`` uses ``_score_one_with_outcome`` directly
+    to recover the precise outcome (``timeout`` vs ``inf``) for metrics.
+    """
+    result = _score_one_with_outcome(program, data, loss_fn, config, X_eval, split)
+    return result[:7]
+
+
+def _score_one_with_outcome(
+    program: Program,
+    data: tuple,
+    loss_fn,
+    config: dict,
+    X_eval=None,
+    split: str = "discover",
+) -> tuple[
+    float,
+    float,
+    jnp.ndarray,
+    dict | None,
+    jnp.ndarray | None,
+    dict | None,
+    jnp.ndarray | None,
+    str,
+]:
+    """Same as ``_score_one_model`` but also returns an outcome label:
+    ``"ok"`` (finite loss), ``"timeout"`` (subprocess killed), ``"inf"``
+    (worker raised or program has no params).
     """
     if program.n_params is None:
         warnings.warn(
-            f"Program #{program.idx} has n_params=None, applying infinite loss, verify that its default_params were set prior to scoring"
+            f"Program #{program.idx} has n_params=None, applying infinite loss, "
+            "verify that its default_params were set prior to scoring"
         )
-        return (float("inf"), float("inf"), None, None, None, None, None)
+        return (float("inf"), float("inf"), None, None, None, None, None, "inf")
 
     ctx = mp.get_context(os.environ.get("EDGAR_MP_START_METHOD", "spawn"))
     queue = ctx.Queue()
@@ -223,12 +254,25 @@ def _score_one_model(
     proc.start()
     try:
         result = queue.get(timeout=config["timeout_s"])
-    except mp.queues.Empty:  # if subproces doesn't respond in time config["timeout_s"]
+    except mp.queues.Empty:
         proc.kill()
         proc.join()
-        return (float("inf"), float("inf"), None, None, None, None, None)
+        return (
+            float("inf"),
+            float("inf"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            "timeout",
+        )
     proc.join()
-    return result
+    final, init, fp, params, samples, params_init, samples_init = result
+    # Worker puts (inf, inf, None, None, None, None, None) on its own exception
+    # path. Treat that as "inf" rather than "timeout" so metrics distinguish them.
+    outcome = "ok" if np.isfinite(final) else "inf"
+    return (final, init, fp, params, samples, params_init, samples_init, outcome)
 
 
 # ── population-level ──
@@ -274,8 +318,18 @@ def score(
 
     Pass X_eval=None to skip fingerprint computation (e.g. on validate scoring,
     so the discover-derived fingerprint isn't overwritten).
+
+    Streams per-program tick lines to ``run.log`` and updates the active
+    ``RunMetrics`` (if any) so the dashboard can show ``score (k/n)`` live.
     """
-    for program in _needs_scoring(population, split):
+    queue = _needs_scoring(population, split)
+    n_total = len(queue)
+    metrics = get_active_metrics()
+    counters = {"ok": 0, "timeout": 0, "inf": 0}
+    latencies_ms: list[float] = []
+
+    for k, program in enumerate(queue, start=1):
+        t0 = time.monotonic()
         (
             final_loss,
             initial_loss,
@@ -284,7 +338,12 @@ def score(
             sample_losses,
             params_init,
             sample_losses_init,
-        ) = _score_one_model(program, X_split, loss_fn, config, X_eval, split)
+            outcome,
+        ) = _score_one_with_outcome(program, X_split, loss_fn, config, X_eval, split)
+        latency_ms = (time.monotonic() - t0) * 1000.0
+        latencies_ms.append(latency_ms)
+        counters[outcome] += 1
+
         loss_pair = getattr(program.program_losses, split)
         loss_pair.init = initial_loss
         loss_pair.final = final_loss
@@ -298,6 +357,21 @@ def score(
             program.sample_losses = sample_losses
         if sample_losses_init is not None and split == "discover":
             program.sample_losses_init = sample_losses_init
+
+        if metrics is not None:
+            metrics.record_score_result(program.idx, latency_ms, outcome)
+
+        # Cheap progress line so the user sees movement during the slow stage.
+        # Print every program for low n_total, every 4 for larger sweeps.
+        tick_every = 1 if n_total <= 12 else 4
+        if metrics is not None and (k == n_total or k % tick_every == 0):
+            avg_s = (sum(latencies_ms) / len(latencies_ms)) / 1000.0
+            stream_line(
+                metrics,
+                f"  [score {split}] {k}/{n_total}  "
+                f"(avg {avg_s:.1f}s, {counters['ok']} ok, "
+                f"{counters['timeout']} timeout, {counters['inf']} inf)",
+            )
 
 
 def rank(

--- a/tests/dashboard/test_metrics.py
+++ b/tests/dashboard/test_metrics.py
@@ -1,0 +1,313 @@
+"""Tests for edgar/io/metrics.py and the dashboard's metrics surfacing.
+
+Two layers:
+- Unit-test the RunMetrics accumulator: stage timing, LLM-call recording,
+  scoring-result recording, percentile math, jsonl round-trip.
+- Contract-test the dashboard API: a synthesised metrics.jsonl + status.json
+  results in /api/state surfacing the totals + current_stage.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from edgar.dashboard import data as dd
+from edgar.dashboard.server import build_app
+from edgar.io.metrics import (
+    METRICS_FILENAME,
+    RunMetrics,
+    get_active_metrics,
+    read_metrics,
+    stage_timer,
+)
+from edgar.io.status import read_status, write_status
+
+
+# ── unit: RunMetrics ──
+
+
+def test_stage_timer_writes_jsonl_row_with_stage_times(tmp_path: Path):
+    log_path = tmp_path / "run.log"
+
+    class _DummyLog:
+        def __init__(self, path: Path):
+            self.file = open(path, "w")
+
+    log = _DummyLog(log_path)
+    with RunMetrics(output_dir=tmp_path, run_log=log, n_gens=2, started_at=0.0) as m:
+        m.start_generation(0)
+        with stage_timer(m, "generate_models", n_items=4):
+            for _ in range(4):
+                m.record_llm_call(
+                    role="model",
+                    model="claude-haiku-4-5",
+                    latency_ms=100.0,
+                    in_tokens=200,
+                    out_tokens=50,
+                    finish_reason="STOP",
+                    retries=0,
+                    ok=True,
+                )
+        with stage_timer(m, "score", n_items=2):
+            m.record_score_result(0, ms=8000.0, outcome="ok")
+            m.record_score_result(1, ms=15000.0, outcome="timeout")
+        row = m.finish_generation()
+    log.file.close()
+
+    assert row["gen"] == 0
+    assert "generate_models" in row["stage_times"]
+    assert "score" in row["stage_times"]
+    assert row["llm_calls"]["model"]["n"] == 4
+    assert row["llm_calls"]["model"]["ok"] == 4
+    assert row["llm_calls"]["model"]["in_tokens_total"] == 800
+    assert row["llm_calls"]["model"]["out_tokens_total"] == 200
+    assert row["scoring"]["n"] == 2
+    assert row["scoring"]["ok"] == 1
+    assert row["scoring"]["timeout"] == 1
+    assert row["scoring"]["latency_ms"]["max"] == 15000.0
+
+    # Disk: metrics.jsonl is written atomically and round-trips.
+    rows = read_metrics(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["gen"] == 0
+    assert rows[0]["llm_calls"]["model"]["n"] == 4
+
+
+def test_get_active_metrics_returns_handle_inside_context(tmp_path: Path):
+    assert get_active_metrics() is None  # outside any run
+    with RunMetrics(output_dir=tmp_path, run_log=None, n_gens=1, started_at=0.0) as m:
+        assert get_active_metrics() is m
+    assert get_active_metrics() is None
+
+
+def test_stage_timer_progress_updates_current_stage(tmp_path: Path):
+    """As LLM calls complete inside a stage, current_stage in status.json
+    should tick (k/n)."""
+    with RunMetrics(output_dir=tmp_path, run_log=None, n_gens=1, started_at=0.0) as m:
+        m.start_generation(0)
+        with stage_timer(m, "generate_models", n_items=3):
+            m.record_llm_call(
+                role="model",
+                model="m",
+                latency_ms=10,
+                in_tokens=1,
+                out_tokens=1,
+                finish_reason=None,
+                retries=0,
+                ok=True,
+            )
+            s = read_status(tmp_path)
+            assert s["current_stage"] == "generate_models (1/3)"
+            m.record_llm_call(
+                role="model",
+                model="m",
+                latency_ms=10,
+                in_tokens=1,
+                out_tokens=1,
+                finish_reason=None,
+                retries=0,
+                ok=True,
+            )
+            s = read_status(tmp_path)
+            assert s["current_stage"] == "generate_models (2/3)"
+            m.record_llm_call(
+                role="model",
+                model="m",
+                latency_ms=10,
+                in_tokens=1,
+                out_tokens=1,
+                finish_reason=None,
+                retries=0,
+                ok=True,
+            )
+            s = read_status(tmp_path)
+            assert s["current_stage"] == "generate_models (3/3)"
+
+
+def test_finish_generation_records_retry_and_failure_counts(tmp_path: Path):
+    with RunMetrics(output_dir=tmp_path, run_log=None, n_gens=1, started_at=0.0) as m:
+        m.start_generation(0)
+        m.record_llm_call(
+            role="param_est",
+            model="m",
+            latency_ms=10,
+            in_tokens=1,
+            out_tokens=1,
+            finish_reason=None,
+            retries=2,
+            ok=True,
+        )
+        m.record_llm_call(
+            role="param_est",
+            model="m",
+            latency_ms=10,
+            in_tokens=1,
+            out_tokens=1,
+            finish_reason=None,
+            retries=0,
+            ok=False,
+        )
+        row = m.finish_generation()
+    st = row["llm_calls"]["param_est"]
+    assert st["n"] == 2
+    assert st["ok"] == 1
+    assert st["retried"] == 1
+
+
+# ── contract: dashboard API ──
+
+
+def _write_taskspec(run_dir: Path) -> None:
+    (run_dir / "task_spec.yaml").write_text(
+        "task_name: t\n"
+        "evolution: {n_generations: 2, n_islands: 2, batch_size: 2}\n"
+        "llms: {model_llm: gemini-2.5-flash, param_est_llm: gemini-2.5-flash, jax_model_translator_llm: gemini-2.5-flash}\n"
+        "scoring: {param_penalty_weight: 0.01}\n"
+        "io: {data_path: x, save_path: y}\n"
+        "project_params: {}\n"
+        "prompt_schemas: {model: {base: X}, param_est: {base: Y}, jax_model: {base: Z}}\n"
+    )
+
+
+def test_dashboard_state_surfaces_metrics_and_totals(tmp_path: Path):
+    run_dir = tmp_path / "05-26" / "00-00-00"
+    run_dir.mkdir(parents=True)
+    _write_taskspec(run_dir)
+
+    rows = [
+        {
+            "gen": 0,
+            "stage_times": {"generate_models": 50.0, "score": 100.0},
+            "llm_calls": {
+                "model": {
+                    "n": 4,
+                    "ok": 4,
+                    "retried": 0,
+                    "in_tokens_total": 1000,
+                    "out_tokens_total": 500,
+                    "models": ["claude-haiku-4-5"],
+                    "latency_ms": {"p50": 1000, "p90": 1500, "max": 2000, "mean": 1100},
+                },
+            },
+            "scoring": {
+                "n": 4,
+                "ok": 3,
+                "timeout": 1,
+                "inf": 0,
+                "latency_ms": {"p50": 8000, "p90": 12000, "max": 15000, "mean": 9000},
+            },
+        },
+        {
+            "gen": 1,
+            "stage_times": {"generate_models": 60.0, "score": 110.0},
+            "llm_calls": {
+                "model": {
+                    "n": 4,
+                    "ok": 3,
+                    "retried": 1,
+                    "in_tokens_total": 1200,
+                    "out_tokens_total": 600,
+                    "models": ["claude-haiku-4-5"],
+                    "latency_ms": {"p50": 1200, "p90": 1800, "max": 2200, "mean": 1300},
+                },
+            },
+            "scoring": {
+                "n": 4,
+                "ok": 4,
+                "timeout": 0,
+                "inf": 0,
+                "latency_ms": {"p50": 7500, "p90": 11000, "max": 14000, "mean": 8500},
+            },
+        },
+    ]
+    (run_dir / METRICS_FILENAME).write_text("".join(json.dumps(r) + "\n" for r in rows))
+
+    write_status(
+        run_dir,
+        state="running",
+        n_gens=2,
+        current_gen=1,
+        started_at=__import__("time").time(),
+        current_stage="score (3/4)",
+        last_metrics=rows[-1],
+    )
+
+    app = build_app([tmp_path])
+    dd._POP_CACHE.clear()
+    dd._CENSUS_CACHE.clear()
+    dd._METRICS_CACHE.clear()
+    with TestClient(app) as client:
+        rid = dd._run_id(run_dir)
+        r = client.get(f"/api/runs/{rid}/state")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["current_stage"] == "score (3/4)"
+        assert body["last_metrics"]["gen"] == 1
+        assert len(body["metrics"]) == 2
+
+        totals = body["totals"]
+        assert totals["in_tokens"] == 2200
+        assert totals["out_tokens"] == 1100
+        assert totals["n_llm_calls"] == 8
+        assert totals["n_llm_retried"] == 1
+        assert totals["n_scored"] == 8
+        assert totals["n_ok"] == 7
+        assert totals["n_timeout"] == 1
+        assert totals["n_inf"] == 0
+        # LLM and scoring seconds are derived from mean × n
+        assert totals["llm_seconds"] == pytest.approx((1100 * 4 + 1300 * 4) / 1000)
+        assert totals["score_seconds"] == pytest.approx((9000 * 4 + 8500 * 4) / 1000)
+
+
+def test_dashboard_summary_also_exposes_totals(tmp_path: Path):
+    run_dir = tmp_path / "05-26" / "11-11-11"
+    run_dir.mkdir(parents=True)
+    _write_taskspec(run_dir)
+    rows = [
+        {
+            "gen": 0,
+            "stage_times": {},
+            "llm_calls": {
+                "model": {
+                    "n": 1,
+                    "ok": 1,
+                    "retried": 0,
+                    "in_tokens_total": 7,
+                    "out_tokens_total": 3,
+                    "models": ["m"],
+                    "latency_ms": {"p50": 1, "p90": 1, "max": 1, "mean": 1},
+                }
+            },
+            "scoring": {
+                "n": 0,
+                "ok": 0,
+                "timeout": 0,
+                "inf": 0,
+                "latency_ms": {"p50": None, "p90": None, "max": None, "mean": None},
+            },
+        }
+    ]
+    (run_dir / METRICS_FILENAME).write_text("".join(json.dumps(r) + "\n" for r in rows))
+    write_status(
+        run_dir,
+        state="complete",
+        n_gens=1,
+        current_gen=0,
+        started_at=__import__("time").time(),
+    )
+
+    app = build_app([tmp_path])
+    dd._POP_CACHE.clear()
+    dd._CENSUS_CACHE.clear()
+    dd._METRICS_CACHE.clear()
+    with TestClient(app) as client:
+        rid = dd._run_id(run_dir)
+        r = client.get(f"/api/runs/{rid}/summary")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["totals"]["in_tokens"] == 7
+        assert body["totals"]["out_tokens"] == 3

--- a/tests/dashboard/test_runner_persist.py
+++ b/tests/dashboard/test_runner_persist.py
@@ -12,6 +12,7 @@ from typing import Iterator
 
 import pytest
 
+from edgar.io.metrics import METRICS_FILENAME, read_metrics
 from edgar.io.status import read_status
 from edgar.run import run
 from tests.system.fake_runner import build_fake_spec
@@ -98,6 +99,30 @@ def test_fake_run_writes_status_and_per_gen_snapshots(fake_output_dir: Path):
     assert (run_dir / "population.jsonl").exists()
     assert (run_dir / "island_census.jsonl").exists()
     assert (run_dir / "task_spec.yaml").exists()
+
+    # metrics.jsonl: one row per phase. Layout = seed (gen=-1) +
+    # one per evolution gen (gen=0..n-1) + one for validate (gen=n_gens).
+    assert (run_dir / METRICS_FILENAME).exists()
+    metric_rows = read_metrics(run_dir)
+    n_gens_cfg = spec.evolution["n_generations"]
+    gens_seen = {r["gen"] for r in metric_rows}
+    assert -1 in gens_seen, "seed phase should be recorded as gen=-1"
+    for g in range(n_gens_cfg):
+        assert g in gens_seen, f"missing gen={g} in metrics.jsonl"
+
+    # Evolution-loop rows: score + all the LLM stages must be timed.
+    loop_rows = [r for r in metric_rows if 0 <= r["gen"] < n_gens_cfg]
+    assert loop_rows, "no generation-loop rows recorded"
+    for r in loop_rows:
+        st = r["stage_times"]
+        assert st, f"gen {r['gen']} has empty stage_times"
+        assert "score" in st, f"gen {r['gen']} missing score timing"
+        assert "generate_models" in st, f"gen {r['gen']} missing generate_models timing"
+        # The fake LLMs all flow through call_llm, so llm_calls is populated.
+        assert r["llm_calls"], f"gen {r['gen']} has empty llm_calls bucket"
+
+    # Final status.json carries the last completed gen's metrics row.
+    assert final_status.get("last_metrics") is not None
 
 
 def test_runner_failure_marks_status_failed(fake_output_dir: Path, monkeypatch):

--- a/tests/system/test_resume.py
+++ b/tests/system/test_resume.py
@@ -1,0 +1,162 @@
+"""
+System test for the resume-from-checkpoint feature.
+
+Strategy:
+1. Build a fake-LLM spec (2 gens × 2 islands × 3 batch = 12 evolved + 2 seed).
+2. Inject a crash mid-gen 1 by raising on the 2nd `score` call (gen 0 scoring
+   succeeds, gen 1 scoring blows up). The runner's `finally` block persists
+   population.jsonl + island_census.jsonl + status.json.
+3. Snapshot disk state: census has 1 entry (gen 0 complete), population has
+   2 seed + 6 evolved = 8 programs.
+4. Build a fresh spec (new fake LLMs — counters reset) and call
+   `run(spec, resume_from=output_dir)`.
+5. Assert the resumed run completes, census grows to 2, population reaches
+   the full 14, the seed/gen-0 programs aren't re-scored (their loss values
+   are preserved across the resume), and gen 0 metric rows are preserved
+   in metrics.jsonl.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from edgar.run import run
+from tests.system.fake_runner import build_fake_spec
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _read_census(path: Path) -> list[list[list[int]]]:
+    with open(path) as f:
+        return json.load(f)
+
+
+def test_resume_after_midrun_crash(tmp_path):
+    # ── 1. First spec: will crash mid-gen 1 ──
+    spec = build_fake_spec(tmp_path / "crash_run")
+    output_dir = Path(spec.output_dir)
+
+    from edgar.scoring.scoring import score as original_score
+
+    call_count = {"n": 0}
+
+    def crashing_score(*args, **kwargs):
+        # Seeds (1) + gen 0 (1) succeed; gen 1 raises.
+        call_count["n"] += 1
+        if call_count["n"] >= 3:
+            raise RuntimeError("injected mid-gen-1 crash")
+        return original_score(*args, **kwargs)
+
+    with patch("edgar.run.score", side_effect=crashing_score):
+        with pytest.raises(RuntimeError, match="injected mid-gen-1 crash"):
+            asyncio.run(run(spec))
+
+    # ── 2. Verify disk state ──
+    # Crash happened during gen 1's score(), AFTER spawn had added 6 shells.
+    # So census has 1 entry (only gen 0 was appended) but population has
+    # 2 seed + 6 gen-0 (scored) + 6 gen-1 (stale, unscored) = 14 programs.
+    census = _read_census(output_dir / "island_census.jsonl")
+    assert len(census) == 1, f"expected 1 completed gen in census, got {len(census)}"
+
+    pop_before = _read_jsonl(output_dir / "population.jsonl")
+    n_seed = 2
+    n_per_gen = spec.evolution["n_islands"] * spec.evolution["batch_size"]
+    n_gens = spec.evolution["n_generations"]
+    assert len(pop_before) == n_seed + 2 * n_per_gen, (
+        f"expected {n_seed + 2 * n_per_gen} programs after crash "
+        f"(2 seed + 6 scored gen-0 + 6 stale gen-1 shells), got {len(pop_before)}"
+    )
+
+    # The trailing programs should be unscored stale shells.
+    n_trailing_unscored = 0
+    for p in reversed(pop_before):
+        if p["program_losses"]["discover"]["final"] is None:
+            n_trailing_unscored += 1
+        else:
+            break
+    assert n_trailing_unscored == n_per_gen, (
+        f"expected {n_per_gen} trailing unscored shells, got {n_trailing_unscored}"
+    )
+
+    # ── 3. Build a fresh spec and resume ──
+    # Fresh build re-uses the same project config + creates fresh fake LLMs.
+    # `resume_from` restamps the spec so writes land back in output_dir.
+    resumed_spec = build_fake_spec(tmp_path / "throwaway")
+    asyncio.run(run(resumed_spec, resume_from=output_dir))
+
+    # ── 4. Final state assertions ──
+    census_after = _read_census(output_dir / "island_census.jsonl")
+    assert len(census_after) == n_gens, (
+        f"expected census to reach n_generations={n_gens}, got {len(census_after)}"
+    )
+
+    # After resume: 6 stale shells dropped, 6 new gen-1 programs added.
+    # Final total: 2 seed + 6 gen-0 + 6 fresh gen-1 = 14.
+    pop_after = _read_jsonl(output_dir / "population.jsonl")
+    expected_total = n_seed + n_gens * n_per_gen
+    assert len(pop_after) == expected_total, (
+        f"expected {expected_total} programs after resume, got {len(pop_after)}"
+    )
+
+    # Pre-crash scored programs (seed + gen 0) survived with their losses
+    # intact (not re-scored). Stale shells at idx 8..13 were dropped, then
+    # replaced by fresh gen-1 programs at the same indices.
+    n_preserved = n_seed + n_per_gen  # 2 seed + 6 gen-0
+    for i in range(n_preserved):
+        assert (
+            pop_before[i]["program_losses"]["discover"]["final"]
+            == pop_after[i]["program_losses"]["discover"]["final"]
+        ), f"pre-crash discover.final loss was overwritten at idx {i}"
+
+    # status flipped to complete.
+    status = json.loads((output_dir / "status.json").read_text())
+    assert status["state"] == "complete", (
+        f"expected state=complete, got {status['state']!r}"
+    )
+
+    # metrics.jsonl contains gen 0 history (preserved from before the crash).
+    metrics = _read_jsonl(output_dir / "metrics.jsonl")
+    gens_logged = {row["gen"] for row in metrics}
+    assert 0 in gens_logged, f"gen 0 missing from metrics.jsonl: {gens_logged}"
+    assert 1 in gens_logged, (
+        f"gen 1 missing from metrics.jsonl (post-resume): {gens_logged}"
+    )
+
+    # Resumed run.log has the RESUMED banner.
+    log_text = (output_dir / "run.log").read_text()
+    assert "RESUMED" in log_text, "run.log missing RESUMED banner after resume"
+
+
+def test_resume_refuses_completed_run(tmp_path):
+    """A clean, fully-completed run should refuse to resume."""
+    spec = build_fake_spec(tmp_path / "clean_run")
+    output_dir = Path(spec.output_dir)
+    asyncio.run(run(spec))
+
+    resumed = build_fake_spec(tmp_path / "throwaway")
+    with pytest.raises(ValueError, match="already has .* completed gens"):
+        asyncio.run(run(resumed, resume_from=output_dir))
+
+
+def test_resume_refuses_missing_dir(tmp_path):
+    """A nonexistent resume_from path should fail loudly at prep time."""
+    spec = build_fake_spec(tmp_path / "throwaway")
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        asyncio.run(run(spec, resume_from=tmp_path / "does_not_exist"))
+
+
+def test_resume_refuses_non_run_dir(tmp_path):
+    """A real dir without task_spec.yaml should fail with a clear message."""
+    fake_dir = tmp_path / "empty_dir"
+    fake_dir.mkdir()
+    spec = build_fake_spec(tmp_path / "throwaway")
+    with pytest.raises(FileNotFoundError, match="task_spec.yaml"):
+        asyncio.run(run(spec, resume_from=fake_dir))

--- a/tutorials/how_to_run.md
+++ b/tutorials/how_to_run.md
@@ -65,6 +65,7 @@ The reduced settings are hard-coded in `edgar/cli.py:TEST_OVERRIDES`. You can
 still pass `--section.key=value` overrides on top of them.
 
 This catches:
+
 - API key works
 - Seed programs compile and score on real data
 - `plot_fn` runs without errors (images appear under `test_output/image_feedback/`)
@@ -96,19 +97,58 @@ edgar run projects/orientation_tuning/config.yaml \
   --io.data_path=/data/other_recording.npy
 ```
 
-### Resume from a saved task_spec
+### Re-run from a saved task_spec
 
-A finished run writes `task_spec.yaml` to its output dir. Passing that file
-instead of `config.yaml` reproduces the run **exactly** — same config, same
-seeds, same LLM names:
+Every run writes `task_spec.yaml` to its output dir **at run start** (right
+after the dir is created), so the file exists for *finished, killed, and
+crashed runs alike*. Passing that file instead of `config.yaml` reproduces the
+run **exactly** — same config, same seeds, same LLM names:
 
 ```bash
 edgar run program_databases/05-24/17-17-45/task_spec.yaml
 ```
 
-Useful for reproducibility checks. Note: this is "re-run from scratch using
-the same recipe", not "continue where we left off". There is no incremental
-resume.
+The relaunch gets a fresh `creation_timestamp`, so it lands in a new dir
+(`program_databases/MM-DD/HH-MM-SS/`); the original run dir is never
+overwritten.
+
+**Important:** this is "re-run from scratch using the same recipe", not
+"continue where we left off". The killed run's `population.jsonl`,
+`island_census.jsonl`, and `image_feedback/` are **not** loaded; generation 0
+starts over. If you want to keep the evolved programs from a killed run, use
+`edgar resume` instead (see next section).
+
+#### Use cases
+
+- **Reproducibility check.** Re-run a finished experiment against the same
+config to confirm determinism, or against a new code version to see if a
+refactor changed the result.
+- **Cold relaunch when you don't want the prior population.** Useful if you
+want to retry a config with a different random seed or different LLM choice
+and start fresh.
+
+### Resume from a checkpoint (continue an interrupted run)
+
+If a run was killed mid-flight (Ctrl-C, network drop, process crashed, laptop
+closed) and you want to **continue from where it stopped**, use:
+
+```bash
+python -m edgar.cli resume program_databases/05-26/14-54-15/
+```
+
+This reads the run's `task_spec.yaml`, restores the population and island
+membership from disk, skips the seed phase (already done), and picks up at
+the next unfinished generation. Outputs are appended back into the same
+directory; `run.log` gets a `──── RESUMED ────` banner so you can tell where
+the original run ended and the resumed work began.
+
+Refuses to resume in a few obvious cases (with clear error messages):
+already-completed runs, empty populations (seed phase never finished), and
+runs that already reached the validation phase.
+
+Caveat: `spec.rng` state is not restored across resume, so spawning/migration
+draws diverge from what a continuous run would have produced. LLM responses
+are non-deterministic anyway, so bit-reproducibility was never on offer.
 
 ### Logging verbosity
 
@@ -164,30 +204,32 @@ edgar run projects/orientation_tuning/config.yaml \
 
 ### Notes on individual keys
 
-| Section | Key | What it controls |
-|---|---|---|
-| `run` | `random_seed` | Seeds spawn/migration RNG; `null` for non-deterministic |
-| `io` | `data_path` | Input data file (`.npy`) consumed by `load_data` |
-| `io` | `save_path` | Output base dir; runs land in `<save_path>/MM-DD/HH-MM-SS/` |
-| `evolution` | `n_generations` | Outer loop iterations |
-| `evolution` | `n_islands` | Independent populations evolving in parallel |
-| `evolution` | `batch_size` | Children per island per generation (= LLM call fan-out) |
-| `evolution` | `critical_population_size` | Hard cap per island; pruned down to this minus `n_migrants` |
-| `evolution` | `n_migrants` | Programs swapped between islands each generation |
-| `evolution` | `topology` | List defining migration graph; must be a permutation of `0..n_islands-1` |
-| `llms` | `num_parents` | Parents shown to LLM per prompt |
-| `llms` | `model_llm` | Model that writes the numpy `model()` code. `claude-*` → Anthropic, `gemini-*` → Google (provider inferred from prefix). Can be a list (cycled per generation). |
-| `llms` | `param_est_llm` | Model that writes `parameter_estimator()` code. Same naming rules as `model_llm`. |
-| `llms` | `jax_model_translator_llm` | Model that translates numpy → JAX. Translation is mechanical — keep this on a small/cheap model (Haiku, Flash-Lite). |
-| `llms` | `max_tokens` | Per-call output limit (Anthropic requires this; Google uses server default if `None`) |
-| `llms` | `log_raw_llm_response` | Print raw model response parts after every call (debug only) |
-| `llms` | `max_lines` | Max lines allowed in a parameter estimator response |
-| `llms` | `retry.*` | HTTP retry policy — best edited in the project's YAML, not on the CLI |
-| `scoring` | `param_penalty_weight` | Complexity penalty: `final_loss += weight * n_params` |
-| `scoring` | `timeout_s` | Wall-clock kill for each scoring subprocess |
-| `scoring` | `gradient_descent.max_iter` | Max optimizer steps when fitting parameters |
-| `scoring` | `gradient_descent.learning_rate` | Adam LR for parameter fitting |
-| `project_params` | (any) | Forwarded as `**kwargs` to `load_data` — keys are project-specific |
+
+| Section          | Key                              | What it controls                                                                                                                                                |
+| ---------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run`            | `random_seed`                    | Seeds spawn/migration RNG; `null` for non-deterministic                                                                                                         |
+| `io`             | `data_path`                      | Input data file (`.npy`) consumed by `load_data`                                                                                                                |
+| `io`             | `save_path`                      | Output base dir; runs land in `<save_path>/MM-DD/HH-MM-SS/`                                                                                                     |
+| `evolution`      | `n_generations`                  | Outer loop iterations                                                                                                                                           |
+| `evolution`      | `n_islands`                      | Independent populations evolving in parallel                                                                                                                    |
+| `evolution`      | `batch_size`                     | Children per island per generation (= LLM call fan-out)                                                                                                         |
+| `evolution`      | `critical_population_size`       | Hard cap per island; pruned down to this minus `n_migrants`                                                                                                     |
+| `evolution`      | `n_migrants`                     | Programs swapped between islands each generation                                                                                                                |
+| `evolution`      | `topology`                       | List defining migration graph; must be a permutation of `0..n_islands-1`                                                                                        |
+| `llms`           | `num_parents`                    | Parents shown to LLM per prompt                                                                                                                                 |
+| `llms`           | `model_llm`                      | Model that writes the numpy `model()` code. `claude-*` → Anthropic, `gemini-*` → Google (provider inferred from prefix). Can be a list (cycled per generation). |
+| `llms`           | `param_est_llm`                  | Model that writes `parameter_estimator()` code. Same naming rules as `model_llm`.                                                                               |
+| `llms`           | `jax_model_translator_llm`       | Model that translates numpy → JAX. Translation is mechanical — keep this on a small/cheap model (Haiku, Flash-Lite).                                            |
+| `llms`           | `max_tokens`                     | Per-call output limit (Anthropic requires this; Google uses server default if `None`)                                                                           |
+| `llms`           | `log_raw_llm_response`           | Print raw model response parts after every call (debug only)                                                                                                    |
+| `llms`           | `max_lines`                      | Max lines allowed in a parameter estimator response                                                                                                             |
+| `llms`           | `retry.*`                        | HTTP retry policy — best edited in the project's YAML, not on the CLI                                                                                           |
+| `scoring`        | `param_penalty_weight`           | Complexity penalty: `final_loss += weight * n_params`                                                                                                           |
+| `scoring`        | `timeout_s`                      | Wall-clock kill for each scoring subprocess                                                                                                                     |
+| `scoring`        | `gradient_descent.max_iter`      | Max optimizer steps when fitting parameters                                                                                                                     |
+| `scoring`        | `gradient_descent.learning_rate` | Adam LR for parameter fitting                                                                                                                                   |
+| `project_params` | (any)                            | Forwarded as `**kwargs` to `load_data` — keys are project-specific                                                                                              |
+
 
 `llms.retry` is a nested dict (`max_retries`, `initial_delay`, `backoff_multiplier`,
 `max_delay`, `retryable_status_codes`). The CLI override format flattens awkwardly
@@ -269,11 +311,14 @@ run Mode 3 → Mode 2 → Mode 1.
 
 ## Troubleshooting
 
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `UserError: ANTHROPIC_API_KEY is not set` / `GOOGLE_API_KEY is not set` | Missing key in `.env` for the provider implied by your model name | Add to `.env`; `load_dotenv()` reads it on `call_llm` import |
-| `[call_llm] HTTP 429` repeatedly on `gemini-*` | Free-tier Gemini rate limit (5 req/min on flash) | Stay on Claude (default), enable Gemini billing, or reduce `n_islands * batch_size` |
-| Scoring hangs then `inf` loss | LLM-generated code hit `scoring.timeout_s` | Expected for pathological programs; check `code.model_jax` in the offender |
-| `RuntimeError: asyncio.run() cannot be called from a running event loop` | You called the CLI from a Jupyter cell | Run from a terminal, or use the notebook-mode walkthrough |
-| `ValueError: topology length (...) must equal n_islands (...)` | `topology` and `n_islands` out of sync after override | Pass both or neither |
-| Output goes to wrong dir | Forgot `--io.save_path` override | Defaults to `program_databases/`; for tests use Mode 2 (lands in `./test_output/`) |
+
+| Symptom                                                                  | Likely cause                                                      | Fix                                                                                 |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `UserError: ANTHROPIC_API_KEY is not set` / `GOOGLE_API_KEY is not set`  | Missing key in `.env` for the provider implied by your model name | Add to `.env`; `load_dotenv()` reads it on `call_llm` import                        |
+| `[call_llm] HTTP 429` repeatedly on `gemini-*`                           | Free-tier Gemini rate limit (5 req/min on flash)                  | Stay on Claude (default), enable Gemini billing, or reduce `n_islands * batch_size` |
+| Scoring hangs then `inf` loss                                            | LLM-generated code hit `scoring.timeout_s`                        | Expected for pathological programs; check `code.model_jax` in the offender          |
+| `RuntimeError: asyncio.run() cannot be called from a running event loop` | You called the CLI from a Jupyter cell                            | Run from a terminal, or use the notebook-mode walkthrough                           |
+| `ValueError: topology length (...) must equal n_islands (...)`           | `topology` and `n_islands` out of sync after override             | Pass both or neither                                                                |
+| Output goes to wrong dir                                                 | Forgot `--io.save_path` override                                  | Defaults to `program_databases/`; for tests use Mode 2 (lands in `./test_output/`)  |
+
+


### PR DESCRIPTION
## Summary

Crashed/killed runs can now be picked up where they left off instead of being re-done from the seed phase + all prior generations.

```bash
edgar resume program_databases/2026-06-04/16-34-32
```

Reads `task_spec.yaml` + `population.jsonl` + `island_census.jsonl` from the target dir, restores in-memory state, drops any trailing un-scored "shells" left over from the crashed generation, then continues the evolution loop from the next generation. The original `run.log` is appended to with a `RESUMED` banner and the existing `metrics.jsonl` history is preserved.

> **Stacked on #40 (observability).** This PR diffs against gamma but contains both the observability commit *and* the resume commit, so review/merge order is:
> 1. Merge #40 (observability).
> 2. Then this PR will rebase to a single resume commit on top.
>
> If preferred, this PR can be re-targeted at `pr/observability` once #40 is merged — happy to do whichever fits the team's workflow.

## Changes

| File | What |
|---|---|
| `edgar/cli.py` | New `resume` subparser + `_build_and_resume` dispatch. |
| `edgar/run.py` | `resume_from` kwarg + helpers (`_prepare_resume`, `_validate_resume_state`, `_drop_trailing_unscored`). Seed phase now runs only when `not resume`; evolution loop starts from the reconstructed `start_gen`. Reuses the saved `started_at` from prior `status.json` so elapsed-time accounting stays correct. |
| `edgar/io/logging.py` | `open_log(append=...)` + RESUMED banner. |
| `edgar/evolution/population.py` | `Population.load()` reconstructs `NotValidated()` sentinels (the JSON serialization flattens to the string `"NOTVALIDATED"`; without this, sort/filter on the validate stage crashes on resume). |
| `tests/system/test_resume.py` | **New.** 4 tests. |
| `tutorials/how_to_run.md` | New "Resume from a checkpoint" section. |

## How "trailing unscored shells" are handled

If a crash happens *after* `spawn()` writes new program shells to `population.jsonl` but *before* `score()` finishes evaluating them, those shells exist but have no losses. On resume, `_drop_trailing_unscored` removes them — the next generation is then spawned fresh. This is conservative: nothing is silently re-scored, no in-progress work is preserved.

## Test plan

- [x] `pytest tests/system/test_resume.py` — **4/4 pass** (~90s).
- [x] `pytest tests/` — **120/120 pass** (+4 = 124 total with resume tests).
- [x] `test_resume_after_midrun_crash` end-to-end test: real injected mid-gen-1 crash → status / population / census on disk reflect the partial run → `resume_from` reads them back → run completes → final population reaches `n_generations` worth of programs and pre-crash losses are preserved unchanged.

## Notes

- Refuses to resume a dir without `task_spec.yaml` (covered by `test_resume_refuses_non_run_dir`).
- Refuses to resume a dir whose `status.json` says `state=complete` (covered by `test_resume_refuses_completed_run`).
- Refuses to resume a missing dir (covered by `test_resume_refuses_missing_dir`).


Made with [Cursor](https://cursor.com)